### PR TITLE
refactor!: Split `HassWSApi` into resource-specific classes

### DIFF
--- a/src/HassClient.Core/HassClient.Core.csproj
+++ b/src/HassClient.Core/HassClient.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.15</Version>
+    <Version>2.0.0</Version>
     <Authors>VFerrer</Authors>
     <Description>A shared package used by HassClient. Do not install this package manually, it will be added as a prerequisite by other packages that require it.</Description>
     <RepositoryUrl>https://github.com/vicfergar/HassClient</RepositoryUrl>

--- a/src/HassClient.Docs.Tests/HassClient.Docs.Tests.csproj
+++ b/src/HassClient.Docs.Tests/HassClient.Docs.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HassClient.Core\HassClient.Core.csproj" />
+    <ProjectReference Include="..\HassClient.WS\HassClient.WS.csproj" />
+  </ItemGroup>
+
+</Project> 

--- a/src/HassClient.Docs.Tests/ReadmeTests.cs
+++ b/src/HassClient.Docs.Tests/ReadmeTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.WS;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace HassClient.Docs.Tests
+{
+    public class ReadmeTests
+    {
+        [Test]
+        public void Readme_CodeSamples_ShouldBeValid()
+        {
+            // Arrange
+            var readmePath = Path.Combine(GetSolutionDirectory(), "../README.md");
+            var readmeContent = File.ReadAllText(readmePath);
+            
+            // Extract all C# code blocks
+            var codeBlocks = ExtractCodeBlocks(readmeContent);
+
+            // Act & Assert
+            foreach (var (code, lineNumber) in codeBlocks)
+            {
+                try 
+                {
+                    AssertCompileCode(code);
+                }
+                catch (AssertionException ex)
+                {
+                    throw new AssertionException($"Code block at line {lineNumber} failed to compile:\n{ex.Message}");
+                }
+            }
+        }
+
+        private static string GetSolutionDirectory()
+        {
+            var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (directory != null && !directory.GetFiles("*.sln").Any())
+            {
+                directory = directory.Parent;
+            }
+            return directory?.FullName ?? throw new Exception("Solution directory not found");
+        }
+
+        private static IEnumerable<(string Code, int LineNumber)> ExtractCodeBlocks(string markdown)
+        {
+            var regex = new Regex(@"```csharp\s*\n(.*?)\n\s*```", RegexOptions.Singleline);
+            var matches = regex.Matches(markdown);
+            
+            foreach (Match match in matches)
+            {
+                // Count newlines before this match to determine line number
+                int lineNumber = markdown[..match.Index].Count(c => c == '\n') + 1;
+                
+                var code = string.Join("\n", 
+                    match.Groups[1].Value.Split('\n')
+                        .Where(line => !line.TrimStart().StartsWith("#")) // Remove lines starting with #
+                        .Where(line => !string.IsNullOrWhiteSpace(line))  // Remove empty lines
+                        .Select(line => line.TrimEnd())                   // Remove trailing whitespace
+                );
+                
+                yield return (code, lineNumber);
+            }
+        }
+
+        private static void AssertCompileCode(string code)
+        {
+            var wrappedCode = WrapCodeIfNeeded(code);
+            var syntaxTree = CSharpSyntaxTree.ParseText(wrappedCode);
+            var compilation = CSharpCompilation.Create("DynamicAssembly",
+                new[] { syntaxTree },
+                GetRequiredReferences(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            using var ms = new MemoryStream();
+            var result = compilation.Emit(ms);
+            
+            if (!result.Success)
+            {
+                var errors = string.Join("\n", result.Diagnostics
+                    .Where(d => d.Severity == DiagnosticSeverity.Error)
+                    .Select(d => d.GetMessage()));
+                throw new AssertionException($"Code block failed to compile with errors:\n{errors}\n\nCode:\n{code}");
+            }
+        }
+
+        private static string WrapCodeIfNeeded(string code)
+        {
+            if (code.Contains("class "))
+                return code;
+
+            var hassApiInit = code.Contains("var hassWSApi") ? "" : 
+                "HassWSApi hassWSApi = new HassWSApi();\n";
+
+            if (code.Contains("private ") || code.Contains("public "))
+                return WrapWithUsings(WrapInClass(code, hassApiInit));
+        
+            return WrapWithUsings(WrapInClassAndMethod(code, hassApiInit));
+        }
+
+        private static string WrapWithUsings(string code) => @$"
+using HassClient;
+using HassClient.Models;
+using HassClient.WS;
+using HassClient.WS.Messages;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DynamicNamespace 
+{{
+    {code}
+}}";
+        private static string WrapInClass(string code, string hassApiInit) => @$"
+public class TestClass 
+{{
+    {hassApiInit}{code}
+}}";
+
+        private static string WrapInClassAndMethod(string code, string hassApiInit) => @$"
+public class TestClass 
+{{
+    public async Task TestMethod()
+    {{
+        {hassApiInit}{code}
+    }}
+}}";
+
+        private static MetadataReference[] GetRequiredReferences()
+        {
+            var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            return new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Service).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(HassWSApi).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(IEnumerable<>).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(JsonConvert).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "netstandard.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Collections.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Linq.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Threading.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Threading.Tasks.dll"))
+            };
+        }
+    }
+} 

--- a/src/HassClient.WS.Tests/EntitySourcesApiTests.cs
+++ b/src/HassClient.WS.Tests/EntitySourcesApiTests.cs
@@ -8,7 +8,7 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task GetEntitySources()
         {
-            var entities = await this.hassWSApi.GetEntitySourcesAsync();
+            var entities = await this.hassWSApi.ListEntitySourcesAsync();
 
             Assert.IsNotNull(entities);
             Assert.IsNotEmpty(entities);

--- a/src/HassClient.WS.Tests/PanelsApiTests.cs
+++ b/src/HassClient.WS.Tests/PanelsApiTests.cs
@@ -20,7 +20,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            this.panels = await this.hassWSApi.GetPanelsAsync();
+            this.panels = await this.hassWSApi.ListPanelsAsync();
 
             Assert.IsNotNull(this.panels);
             Assert.IsNotEmpty(this.panels);

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/AreaRegistryApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/AreaRegistryApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
             if (this.testArea == null)
             {
                 this.testArea = new Area(MockHelpers.GetRandomTestName(), icon: "mdi:home", aliases: new[] { "alias1", "alias2" }, labels: new[] { "label1", "label2" });
-                var result = await this.hassWSApi.CreateAreaAsync(testArea);
+                var result = await this.hassWSApi.Areas.CreateAsync(testArea);
                 Assert.IsTrue(result, "SetUp failed");
                 return;
             }
@@ -32,7 +32,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetAreas()
         {
-            var areas = await this.hassWSApi.GetAreasAsync();
+            var areas = await this.hassWSApi.Areas.ListAsync();
 
             Assert.NotNull(areas);
             Assert.IsNotEmpty(areas);
@@ -53,7 +53,7 @@ namespace HassClient.WS.Tests
             this.testArea.Aliases.Add("alias3");
             this.testArea.Labels.Add("label3");
             var originalModificationDate = this.testArea.ModifiedAt;
-            var result = await this.hassWSApi.UpdateAreaAsync(this.testArea);
+            var result = await this.hassWSApi.Areas.UpdateAsync(this.testArea);
 
             Assert.IsTrue(result);
             Assert.False(this.testArea.HasPendingChanges);
@@ -69,7 +69,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteAreaAsync(this.testArea);
+            var result = await this.hassWSApi.Areas.DeleteAsync(this.testArea);
             var deletedArea = this.testArea;
             this.testArea = null;
 

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/CategoryRegistryApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/CategoryRegistryApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
             if (this.testCategory == null)
             {
                 this.testCategory = new Category(MockHelpers.GetRandomTestName(), icon: "mdi:lamp", scope:  "test_scope");
-                var result = await this.hassWSApi.CreateCategoryAsync(this.testCategory);
+                var result = await this.hassWSApi.Categories.CreateAsync(this.testCategory);
                 Assert.IsTrue(result, "SetUp failed");
                 return;
             }
@@ -33,7 +33,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetCategories()
         {
-            var categories = await this.hassWSApi.GetCategoriesAsync("test_scope");
+            var categories = await this.hassWSApi.Categories.ListAsync("test_scope");
 
             Assert.NotNull(categories);
             Assert.IsNotEmpty(categories);
@@ -46,7 +46,7 @@ namespace HassClient.WS.Tests
             this.testCategory.Name = MockHelpers.GetRandomTestName();
             this.testCategory.Icon = "mdi:sofa";
             var originalModificationDate = this.testCategory.ModifiedAt;
-            var result = await this.hassWSApi.UpdateCategoryAsync(this.testCategory);
+            var result = await this.hassWSApi.Categories.UpdateAsync(this.testCategory);
 
             Assert.IsTrue(result);
             Assert.False(this.testCategory.HasPendingChanges);
@@ -62,7 +62,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteCategoryAsync(this.testCategory);
+            var result = await this.hassWSApi.Categories.DeleteAsync(this.testCategory);
             var deletedCategory = this.testCategory;
             this.testCategory = null;
 

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/DeviceRegistryApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/DeviceRegistryApiTests.cs
@@ -11,7 +11,7 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task GetDevices()
         {
-            var devices = await this.hassWSApi.GetDevicesAsync();
+            var devices = await this.hassWSApi.Devices.ListAsync();
 
             Assert.NotNull(devices);
             Assert.IsNotEmpty(devices);
@@ -27,14 +27,14 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task UpdateDeviceName()
         {
-            var devices = await this.hassWSApi.GetDevicesAsync();
+            var devices = await this.hassWSApi.Devices.ListAsync();
             var testDevice = devices.FirstOrDefault();
             Assert.NotNull(testDevice, "SetUp failed");
 
             var newName = $"TestDevice_{DateTime.Now.Ticks}";
             testDevice.Name = newName;
             var originalModificationDate = testDevice.ModifiedAt;
-            var result = await this.hassWSApi.UpdateDeviceAsync(testDevice);
+            var result = await this.hassWSApi.Devices.UpdateAsync(testDevice);
 
             Assert.IsTrue(result);
             Assert.IsFalse(testDevice.HasPendingChanges);
@@ -45,14 +45,14 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task UpdateDeviceAreaId()
         {
-            var devices = await this.hassWSApi.GetDevicesAsync();
+            var devices = await this.hassWSApi.Devices.ListAsync();
             var testDevice = devices.FirstOrDefault();
             Assert.NotNull(testDevice, "SetUp failed");
 
             var newAreaId = $"{DateTime.Now.Ticks}";
             testDevice.AreaId = newAreaId;
             var originalModificationDate = testDevice.ModifiedAt;
-            var result = await this.hassWSApi.UpdateDeviceAsync(testDevice);
+            var result = await this.hassWSApi.Devices.UpdateAsync(testDevice);
 
             Assert.IsTrue(result);
             Assert.IsFalse(testDevice.HasPendingChanges);
@@ -63,14 +63,14 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task UpdateDeviceLabels()
         {
-            var devices = await this.hassWSApi.GetDevicesAsync();
+            var devices = await this.hassWSApi.Devices.ListAsync();
             var testDevice = devices.FirstOrDefault();
             Assert.NotNull(testDevice, "SetUp failed");
 
             var newLabel = $"TestLabel_{DateTime.Now.Ticks}";
             testDevice.Labels.Add(newLabel);
             var originalModificationDate = testDevice.ModifiedAt;
-            var result = await this.hassWSApi.UpdateDeviceAsync(testDevice);
+            var result = await this.hassWSApi.Devices.UpdateAsync(testDevice);
 
             Assert.IsTrue(result);
             Assert.IsFalse(testDevice.HasPendingChanges);

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/EntityRegistryApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/EntityRegistryApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
         {
             await base.OneTimeSetUp();
             this.testInputBoolean = new InputBoolean(MockHelpers.GetRandomTestName(), "mdi:switch");
-            var result = await this.hassWSApi.CreateStorageEntityRegistryEntryAsync(this.testInputBoolean);
+            var result = await this.hassWSApi.StorageEntities.CreateAsync(this.testInputBoolean);
             this.testEntityId = this.testInputBoolean.EntityId;
 
             Assert.IsTrue(result, "SetUp failed");
@@ -27,13 +27,13 @@ namespace HassClient.WS.Tests
         protected override async Task OneTimeTearDown()
         {
             await base.OneTimeTearDown();
-            await this.hassWSApi.DeleteStorageEntityRegistryEntryAsync(this.testInputBoolean);
+            await this.hassWSApi.StorageEntities.DeleteAsync(this.testInputBoolean);
         }
 
         [Test]
         public async Task GetEntities()
         {
-            var entities = await this.hassWSApi.GetEntitiesAsync();
+            var entities = await this.hassWSApi.Entities.ListAsync();
 
             Assert.IsNotNull(entities);
             Assert.IsNotEmpty(entities);
@@ -54,7 +54,7 @@ namespace HassClient.WS.Tests
         [Test]
         public void GetEntityWithNullEntityIdThrows()
         {
-            Assert.ThrowsAsync<ArgumentException>(() => this.hassWSApi.GetEntityAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(() => this.hassWSApi.Entities.GetAsync(null));
         }
 
         [Test]
@@ -62,14 +62,14 @@ namespace HassClient.WS.Tests
         {
             var testEntity = new EntityRegistryEntry("switch.TestEntity", null, null);
 
-            Assert.ThrowsAsync<ArgumentException>(() => this.hassWSApi.UpdateEntityAsync(testEntity, testEntity.EntityId));
+            Assert.ThrowsAsync<ArgumentException>(() => this.hassWSApi.Entities.UpdateAsync(testEntity, testEntity.EntityId));
         }
 
         [Test]
         public async Task GetEntity()
         {
             var entityId = "light.bed_light";
-            var entity = await this.hassWSApi.GetEntityAsync(entityId);
+            var entity = await this.hassWSApi.Entities.GetAsync(entityId);
 
             Assert.IsNotNull(entity);
             Assert.IsNotNull(entity.Id);
@@ -80,7 +80,7 @@ namespace HassClient.WS.Tests
         [Test, Order(1), NonParallelizable]
         public async Task GetCreatedEntity()
         {
-            var entity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var entity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
 
             Assert.IsNotNull(entity);
             Assert.IsNotNull(entity.Id);
@@ -96,9 +96,9 @@ namespace HassClient.WS.Tests
         [TestCase(false)]
         public async Task UpdateEntityDisable(bool disable)
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
 
-            var result = await this.hassWSApi.UpdateEntityAsync(testEntity, disable: disable);
+            var result = await this.hassWSApi.Entities.UpdateAsync(testEntity, disable: disable);
 
             Assert.IsTrue(result);
             Assert.AreEqual(this.testEntityId, testEntity.EntityId);
@@ -109,11 +109,11 @@ namespace HassClient.WS.Tests
         public async Task UpdateEntityName()
         {
             var newName = MockHelpers.GetRandomTestName();
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
 
             testEntity.Name = newName;
             var originalModificationDate = testEntity.ModifiedAt;
-            var result = await this.hassWSApi.UpdateEntityAsync(testEntity);
+            var result = await this.hassWSApi.Entities.UpdateAsync(testEntity);
 
             Assert.IsTrue(result);
             Assert.AreEqual(this.testEntityId, testEntity.EntityId);
@@ -125,12 +125,12 @@ namespace HassClient.WS.Tests
         [Test, Order(1), NonParallelizable]
         public async Task UpdateEntityIcon()
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
 
             var newIcon = "mdi:fan";
             testEntity.Icon = newIcon;
             var originalModificationDate = testEntity.ModifiedAt;
-            var result = await this.hassWSApi.UpdateEntityAsync(testEntity);
+            var result = await this.hassWSApi.Entities.UpdateAsync(testEntity);
 
             Assert.IsTrue(result);
             Assert.AreEqual(this.testEntityId, testEntity.EntityId);
@@ -142,11 +142,11 @@ namespace HassClient.WS.Tests
         [Test, Order(1), NonParallelizable]
         public async Task UpdateEntityAliases()
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
                 
             testEntity.Aliases.Add("alias3");
             var originalModificationDate = testEntity.ModifiedAt;
-            var result = await this.hassWSApi.UpdateEntityAsync(testEntity);
+            var result = await this.hassWSApi.Entities.UpdateAsync(testEntity);
 
             Assert.IsTrue(result);
             Assert.AreEqual(this.testEntityId, testEntity.EntityId);
@@ -157,11 +157,11 @@ namespace HassClient.WS.Tests
         [Test, Order(1), NonParallelizable]
         public async Task UpdateEntityLabels()
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
                 
             testEntity.Labels.Add("label3");
             var originalModificationDate = testEntity.ModifiedAt;
-            var result = await this.hassWSApi.UpdateEntityAsync(testEntity);
+            var result = await this.hassWSApi.Entities.UpdateAsync(testEntity);
 
             Assert.IsTrue(result);
             Assert.AreEqual(this.testEntityId, testEntity.EntityId);
@@ -172,14 +172,14 @@ namespace HassClient.WS.Tests
         [Test, Order(1)]
         public async Task RefreshEntity()
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
             var clonedEntity = testEntity.Clone();
             clonedEntity.Name = MockHelpers.GetRandomTestName();
-            var result = await this.hassWSApi.UpdateEntityAsync(clonedEntity);
+            var result = await this.hassWSApi.Entities.UpdateAsync(clonedEntity);
             Assert.IsTrue(result, "SetUp failed");
             Assert.False(testEntity.HasPendingChanges, "SetUp failed");
 
-            result = await this.hassWSApi.RefreshEntityAsync(testEntity);
+            result = await this.hassWSApi.Entities.RefreshAsync(testEntity);
             Assert.IsTrue(result);
             Assert.AreEqual(clonedEntity.Name, testEntity.Name);
         }
@@ -187,11 +187,11 @@ namespace HassClient.WS.Tests
         [Test, Order(2), NonParallelizable]
         public async Task UpdateEntityId()
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
             var newEntityId = this.testEntityId + 1;
             
             var originalModificationDate = testEntity.ModifiedAt;
-            var result = await this.hassWSApi.UpdateEntityAsync(testEntity, newEntityId);
+            var result = await this.hassWSApi.Entities.UpdateAsync(testEntity, newEntityId);
 
             Assert.IsTrue(result);
             Assert.AreEqual(newEntityId, testEntity.EntityId);
@@ -204,19 +204,19 @@ namespace HassClient.WS.Tests
         [Test, Order(3)]
         public async Task UpdateWithForce()
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
             var initialName = testEntity.Name;
             var initialIcon = testEntity.Icon;
             var initialDisabledBy = testEntity.DisabledBy;
             var clonedEntry = testEntity.Clone();
             clonedEntry.Name = $"{initialName}_cloned";
             clonedEntry.Icon = $"{initialIcon}_cloned";
-            var result = await this.hassWSApi.UpdateEntityAsync(clonedEntry, disable: true);
+            var result = await this.hassWSApi.Entities.UpdateAsync(clonedEntry, disable: true);
             Assert.IsTrue(result, "SetUp failed");
             Assert.False(testEntity.HasPendingChanges, "SetUp failed");
 
             var originalModificationDate = testEntity.ModifiedAt;
-            result = await this.hassWSApi.UpdateEntityAsync(testEntity, disable: false, forceUpdate: true);
+            result = await this.hassWSApi.Entities.UpdateAsync(testEntity, disable: false, forceUpdate: true);
             Assert.IsTrue(result);
             Assert.AreEqual(initialName, testEntity.Name);
             Assert.AreEqual(initialIcon, testEntity.Icon);
@@ -227,9 +227,9 @@ namespace HassClient.WS.Tests
         [Test, Order(4), NonParallelizable]
         public async Task DeleteEntity()
         {
-            var testEntity = await this.hassWSApi.GetEntityAsync(this.testEntityId);
-            var result = await this.hassWSApi.DeleteEntityAsync(testEntity);
-            var testEntity1 = await this.hassWSApi.GetEntityAsync(this.testEntityId);
+            var testEntity = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
+            var result = await this.hassWSApi.Entities.DeleteAsync(testEntity);
+            var testEntity1 = await this.hassWSApi.Entities.GetAsync(this.testEntityId);
 
             Assert.IsTrue(result);
             Assert.IsNull(testEntity1);

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/FloorRegistryApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/FloorRegistryApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
             if (this.testFloor == null)
             {
                 this.testFloor = new Floor(MockHelpers.GetRandomTestName(), "mdi:lamp", 1, new[] { "alias1", "alias2" });
-                var result = await this.hassWSApi.CreateFloorAsync(this.testFloor);
+                var result = await this.hassWSApi.Floors.CreateAsync(this.testFloor);
                 Assert.IsTrue(result, "SetUp failed");
                 return;
             }
@@ -34,7 +34,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetFloors()
         {
-            var floors = await this.hassWSApi.GetFloorsAsync();
+            var floors = await this.hassWSApi.Floors.ListAsync();
 
             Assert.NotNull(floors);
             Assert.IsNotEmpty(floors);
@@ -49,7 +49,7 @@ namespace HassClient.WS.Tests
             this.testFloor.Level = 2;
             this.testFloor.Aliases.Add("alias3");
             var originalModificationDate = this.testFloor.ModifiedAt;
-            var result = await this.hassWSApi.UpdateFloorAsync(this.testFloor);
+            var result = await this.hassWSApi.Floors.UpdateAsync(this.testFloor);
 
             Assert.IsTrue(result);
             Assert.False(this.testFloor.HasPendingChanges);
@@ -65,7 +65,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteFloorAsync(this.testFloor);
+            var result = await this.hassWSApi.Floors.DeleteAsync(this.testFloor);
             var deletedFloor = this.testFloor;
             this.testFloor = null;
 

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/LabelRegistryApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/LabelRegistryApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
             if (this.testLabel == null)
             {
                 this.testLabel = new Label(MockHelpers.GetRandomTestName(), "mdi:lamp", "#000000", "Test description");
-                var result = await this.hassWSApi.CreateLabelAsync(this.testLabel);
+                var result = await this.hassWSApi.Labels.CreateAsync(this.testLabel);
                 Assert.IsTrue(result, "SetUp failed");
                 return;
             }
@@ -34,7 +34,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetLabels()
         {
-            var labels = await this.hassWSApi.GetLabelsAsync();
+            var labels = await this.hassWSApi.Labels.ListAsync();
 
             Assert.NotNull(labels);
             Assert.IsNotEmpty(labels);
@@ -48,7 +48,7 @@ namespace HassClient.WS.Tests
             this.testLabel.Color = "#FFFFFF";
             this.testLabel.Description = "Updated description"; 
             var originalModificationDate = this.testLabel.ModifiedAt;
-            var result = await this.hassWSApi.UpdateLabelAsync(this.testLabel);
+            var result = await this.hassWSApi.Labels.UpdateAsync(this.testLabel);
 
             Assert.IsTrue(result);
             Assert.False(this.testLabel.HasPendingChanges);
@@ -64,7 +64,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteLabelAsync(this.testLabel);
+            var result = await this.hassWSApi.Labels.DeleteAsync(this.testLabel);
             var deletedLabel = this.testLabel;
             this.testLabel = null;
 

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/StorageEntityRegistryEntryApiTests/InputBooleanApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/StorageEntityRegistryEntryApiTests/InputBooleanApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
             if (this.testInputBoolean == null)
             {
                 this.testInputBoolean = new InputBoolean(MockHelpers.GetRandomTestName(), "mdi:fan", true);
-                var result = await this.hassWSApi.CreateStorageEntityRegistryEntryAsync(this.testInputBoolean);
+                var result = await this.hassWSApi.StorageEntities.CreateAsync(this.testInputBoolean);
 
                 Assert.IsTrue(result, "SetUp failed");
                 return;
@@ -34,7 +34,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetInputBooleans()
         {
-            var result = await this.hassWSApi.GetStorageEntityRegistryEntriesAsync<InputBoolean>();
+            var result = await this.hassWSApi.StorageEntities.ListAsync<InputBoolean>();
 
             Assert.NotNull(result);
             Assert.IsNotEmpty(result);
@@ -52,7 +52,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateInputBooleanName()
         {
             this.testInputBoolean.Name = $"{nameof(InputBooleanApiTests)}_{DateTime.Now.Ticks}";
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testInputBoolean);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testInputBoolean);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testInputBoolean.HasPendingChanges);
@@ -62,7 +62,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateInputBooleanInitial()
         {
             this.testInputBoolean.Initial = false;
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testInputBoolean);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testInputBoolean);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testInputBoolean.HasPendingChanges);
@@ -72,7 +72,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateInputBooleanIcon()
         {
             this.testInputBoolean.Icon = $"mdi:lightbulb";
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testInputBoolean);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testInputBoolean);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testInputBoolean.HasPendingChanges);
@@ -88,11 +88,11 @@ namespace HassClient.WS.Tests
             clonedEntry.Name = $"{initialName}_cloned";
             clonedEntry.Icon = $"{initialIcon}_cloned";
             clonedEntry.Initial = !initialInitial;
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(clonedEntry);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(clonedEntry);
             Assert.IsTrue(result, "SetUp failed");
             Assert.False(this.testInputBoolean.HasPendingChanges, "SetUp failed");
 
-            result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testInputBoolean, forceUpdate: true);
+            result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testInputBoolean, forceUpdate: true);
             Assert.IsTrue(result);
             Assert.AreEqual(initialName, this.testInputBoolean.Name);
             Assert.AreEqual(initialIcon, this.testInputBoolean.Icon);
@@ -109,7 +109,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteStorageEntityRegistryEntryAsync(this.testInputBoolean);
+            var result = await this.hassWSApi.StorageEntities.DeleteAsync(this.testInputBoolean);
             var deletedInputBoolean = this.testInputBoolean;
             this.testInputBoolean = null;
 

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/StorageEntityRegistryEntryApiTests/PersonApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/StorageEntityRegistryEntryApiTests/PersonApiTests.cs
@@ -18,11 +18,11 @@ namespace HassClient.WS.Tests
             if (this.testPerson == null)
             {
                 var testUser = new User(MockHelpers.GetRandomTestName(), false);
-                var result = await this.hassWSApi.CreateUserAsync(testUser);
+                var result = await this.hassWSApi.Users.CreateAsync(testUser);
                 Assert.IsTrue(result, "SetUp failed");
 
                 this.testPerson = new Person(testUser.Name, testUser);
-                result = await this.hassWSApi.CreateStorageEntityRegistryEntryAsync(this.testPerson);
+                result = await this.hassWSApi.StorageEntities.CreateAsync(this.testPerson);
                 Assert.IsTrue(result, "SetUp failed");
                 return;
             }
@@ -37,7 +37,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetPersons()
         {
-            var result = await this.hassWSApi.GetStorageEntityRegistryEntriesAsync<Person>();
+            var result = await this.hassWSApi.StorageEntities.ListAsync<Person>();
 
             Assert.NotNull(result);
             Assert.IsNotEmpty(result);
@@ -53,7 +53,7 @@ namespace HassClient.WS.Tests
         public async Task UpdatePersonName()
         {
             this.testPerson.Name = $"{nameof(PersonApiTests)}_{DateTime.Now.Ticks}";
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testPerson);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testPerson);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testPerson.HasPendingChanges);
@@ -63,7 +63,7 @@ namespace HassClient.WS.Tests
         public async Task UpdatePersonPicture()
         {
             this.testPerson.Picture = "test/Picture.png";
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testPerson);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testPerson);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testPerson.HasPendingChanges);
@@ -73,7 +73,7 @@ namespace HassClient.WS.Tests
         public async Task UpdatePersonDeviceTrackers()
         {
             this.testPerson.DeviceTrackers.Add($"device_tracker.{MockHelpers.GetRandomTestName()}");
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testPerson);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testPerson);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testPerson.HasPendingChanges);
@@ -83,11 +83,11 @@ namespace HassClient.WS.Tests
         public async Task UpdatePersonUserId()
         {
             var testUser = new User(MockHelpers.GetRandomTestName(), false);
-            var result = await this.hassWSApi.CreateUserAsync(testUser);
+            var result = await this.hassWSApi.Users.CreateAsync(testUser);
             Assert.IsTrue(result, "SetUp failed");
 
             this.testPerson.ChangeUser(testUser);
-            result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testPerson);
+            result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testPerson);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testPerson.HasPendingChanges);
@@ -99,11 +99,11 @@ namespace HassClient.WS.Tests
             var initialName = this.testPerson.Name;
             var clonedEntry = this.testPerson.Clone();
             clonedEntry.Name = $"{initialName}_cloned";
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(clonedEntry);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(clonedEntry);
             Assert.IsTrue(result, "SetUp failed");
             Assert.False(this.testPerson.HasPendingChanges, "SetUp failed");
 
-            result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testPerson, forceUpdate: true);
+            result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testPerson, forceUpdate: true);
             Assert.IsTrue(result);
             Assert.AreEqual(initialName, this.testPerson.Name);
             Assert.IsFalse(this.testPerson.HasPendingChanges);
@@ -118,7 +118,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteStorageEntityRegistryEntryAsync(this.testPerson);
+            var result = await this.hassWSApi.StorageEntities.DeleteAsync(this.testPerson);
             var deletedPerson = this.testPerson;
             this.testPerson = null;
 

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/StorageEntityRegistryEntryApiTests/ZoneApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/StorageEntityRegistryEntryApiTests/ZoneApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
             if (this.testZone == null)
             {
                 this.testZone = new Zone(MockHelpers.GetRandomTestName(), 20.1f, 34.6f, 10.5f, "mdi:fan", true);
-                var result = await this.hassWSApi.CreateStorageEntityRegistryEntryAsync(this.testZone);
+                var result = await this.hassWSApi.StorageEntities.CreateAsync(this.testZone);
 
                 Assert.IsTrue(result, "SetUp failed");
                 return;
@@ -34,7 +34,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetZones()
         {
-            var result = await this.hassWSApi.GetStorageEntityRegistryEntriesAsync<Zone>();
+            var result = await this.hassWSApi.StorageEntities.ListAsync<Zone>();
 
             Assert.NotNull(result);
             Assert.IsNotEmpty(result);
@@ -55,7 +55,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateZoneName()
         {
             this.testZone.Name = $"{nameof(ZoneApiTests)}_{DateTime.Now.Ticks}";
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testZone);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testZone);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testZone.HasPendingChanges);
@@ -65,7 +65,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateZoneInitial()
         {
             this.testZone.IsPassive = false;
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testZone);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testZone);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testZone.HasPendingChanges);
@@ -75,7 +75,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateZoneIcon()
         {
             this.testZone.Icon = $"mdi:lightbulb";
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testZone);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testZone);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testZone.HasPendingChanges);
@@ -97,11 +97,11 @@ namespace HassClient.WS.Tests
             clonedEntry.Latitude = initialLatitude + 15f;
             clonedEntry.Radius = initialRadius + 15f;
             clonedEntry.IsPassive = !initialIsPassive;
-            var result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(clonedEntry);
+            var result = await this.hassWSApi.StorageEntities.UpdateAsync(clonedEntry);
             Assert.IsTrue(result, "SetUp failed");
             Assert.False(this.testZone.HasPendingChanges, "SetUp failed");
 
-            result = await this.hassWSApi.UpdateStorageEntityRegistryEntryAsync(this.testZone, forceUpdate: true);
+            result = await this.hassWSApi.StorageEntities.UpdateAsync(this.testZone, forceUpdate: true);
             Assert.IsTrue(result);
             Assert.AreEqual(initialName, this.testZone.Name);
             Assert.AreEqual(initialIcon, this.testZone.Icon);
@@ -121,7 +121,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteStorageEntityRegistryEntryAsync(this.testZone);
+            var result = await this.hassWSApi.StorageEntities.DeleteAsync(this.testZone);
             var deletedZone = this.testZone;
             this.testZone = null;
 

--- a/src/HassClient.WS.Tests/RegistryEntryApiTests/UserRegistryApiTests.cs
+++ b/src/HassClient.WS.Tests/RegistryEntryApiTests/UserRegistryApiTests.cs
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
             if (this.testUser == null)
             {
                 this.testUser = new User(MockHelpers.GetRandomTestName());
-                var result = await this.hassWSApi.CreateUserAsync(this.testUser);
+                var result = await this.hassWSApi.Users.CreateAsync(this.testUser);
 
                 Assert.IsTrue(result, "SetUp failed");
                 return;
@@ -37,7 +37,7 @@ namespace HassClient.WS.Tests
         [Test, Order(2)]
         public async Task GetUsers()
         {
-            var users = await this.hassWSApi.GetUsersAsync();
+            var users = await this.hassWSApi.Users.ListAsync();
 
             Assert.NotNull(users);
             Assert.IsNotEmpty(users);
@@ -51,7 +51,7 @@ namespace HassClient.WS.Tests
         {
             var updatedName = MockHelpers.GetRandomTestName();
             this.testUser.Name = updatedName;
-            var result = await this.hassWSApi.UpdateUserAsync(this.testUser);
+            var result = await this.hassWSApi.Users.UpdateAsync(this.testUser);
 
             Assert.IsTrue(result);
             Assert.AreEqual(updatedName, this.testUser.Name);
@@ -61,7 +61,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateUserIsActive()
         {
             this.testUser.IsActive = false;
-            var result = await this.hassWSApi.UpdateUserAsync(this.testUser);
+            var result = await this.hassWSApi.Users.UpdateAsync(this.testUser);
 
             Assert.IsTrue(result);
             Assert.IsFalse(this.testUser.IsActive);
@@ -71,7 +71,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateUserIsLocalOnly()
         {
             this.testUser.IsLocalOnly = true;
-            var result = await this.hassWSApi.UpdateUserAsync(this.testUser);
+            var result = await this.hassWSApi.Users.UpdateAsync(this.testUser);
 
             Assert.IsTrue(result);
             Assert.IsTrue(this.testUser.IsLocalOnly);
@@ -81,7 +81,7 @@ namespace HassClient.WS.Tests
         public async Task UpdateUserIsAdministrator()
         {
             this.testUser.IsAdministrator = true;
-            var result = await this.hassWSApi.UpdateUserAsync(this.testUser);
+            var result = await this.hassWSApi.Users.UpdateAsync(this.testUser);
 
             Assert.IsTrue(result);
             Assert.IsTrue(this.testUser.IsAdministrator);
@@ -99,11 +99,11 @@ namespace HassClient.WS.Tests
             clonedEntry.IsAdministrator = !this.testUser.IsAdministrator;
             clonedEntry.IsActive = !initialIsActive;
             clonedEntry.IsLocalOnly = !initialIsLocalOnly;
-            var result = await this.hassWSApi.UpdateUserAsync(clonedEntry);
+            var result = await this.hassWSApi.Users.UpdateAsync(clonedEntry);
             Assert.IsTrue(result, "SetUp failed");
             Assert.False(this.testUser.HasPendingChanges, "SetUp failed");
 
-            result = await this.hassWSApi.UpdateUserAsync(this.testUser, forceUpdate: true);
+            result = await this.hassWSApi.Users.UpdateAsync(this.testUser, forceUpdate: true);
             Assert.IsTrue(result);
             Assert.AreEqual(initialName, this.testUser.Name);
             Assert.AreEqual(initialGroupIds, this.testUser.GroupIds);
@@ -120,7 +120,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            var result = await this.hassWSApi.DeleteUserAsync(this.testUser);
+            var result = await this.hassWSApi.Users.DeleteAsync(this.testUser);
             var deletedUser = this.testUser;
             this.testUser = null;
 

--- a/src/HassClient.WS.Tests/ServiceApiTests.cs
+++ b/src/HassClient.WS.Tests/ServiceApiTests.cs
@@ -9,7 +9,7 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task GetServices()
         {
-            var services = await this.hassWSApi.GetServicesAsync();
+            var services = await this.hassWSApi.Services.ListAsync();
 
             Assert.NotNull(services);
             Assert.IsNotEmpty(services);
@@ -18,7 +18,7 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task CallService()
         {
-            var result = await this.hassWSApi.CallServiceAsync("homeassistant", "check_config");
+            var result = await this.hassWSApi.Services.CallAsync("homeassistant", "check_config");
 
             Assert.NotNull(result);
         }
@@ -26,7 +26,7 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task CallServiceForEntities()
         {
-            var result = await this.hassWSApi.CallServiceForEntitiesAsync("homeassistant", "update_entity", "sun.sun");
+            var result = await this.hassWSApi.Services.CallForEntitiesAsync("homeassistant", "update_entity", "sun.sun");
 
             Assert.NotNull(result);
         }
@@ -34,7 +34,7 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task CallServiceWithKnownDomain()
         {
-            var result = await this.hassWSApi.CallServiceAsync(KnownDomains.Homeassistant, KnownServices.CheckConfig);
+            var result = await this.hassWSApi.Services.CallAsync(KnownDomains.Homeassistant, KnownServices.CheckConfig);
 
             Assert.IsTrue(result);
         }
@@ -42,7 +42,7 @@ namespace HassClient.WS.Tests
         [Test]
         public async Task CallServiceForEntitiesWithKnownDomain()
         {
-            var result = await this.hassWSApi.CallServiceForEntitiesAsync(KnownDomains.Homeassistant, KnownServices.UpdateEntity, "sun.sun");
+            var result = await this.hassWSApi.Services.CallForEntitiesAsync(KnownDomains.Homeassistant, KnownServices.UpdateEntity, "sun.sun");
 
             Assert.IsTrue(result);
         }

--- a/src/HassClient.WS.Tests/StatesApiTests.cs
+++ b/src/HassClient.WS.Tests/StatesApiTests.cs
@@ -20,7 +20,7 @@ namespace HassClient.WS.Tests
                 return;
             }
 
-            this.states = await this.hassWSApi.GetStatesAsync();
+            this.states = await this.hassWSApi.ListStatesAsync();
 
             Assert.IsNotNull(this.states);
             Assert.IsNotEmpty(this.states);

--- a/src/HassClient.WS.Tests/SubscriptionApiTests.cs
+++ b/src/HassClient.WS.Tests/SubscriptionApiTests.cs
@@ -16,7 +16,7 @@ namespace HassClient.WS.Tests
         private async Task<EventData<StateChangedEvent>> ForceStateChangedAndGetEventData(MockEventListener listener)
         {
             var domain = testEntityId.GetDomain();
-            var update = await this.hassWSApi.CallServiceForEntitiesAsync(domain, "toggle", testEntityId);
+            var update = await this.hassWSApi.Services.CallForEntitiesAsync(domain, "toggle", testEntityId);
             Assert.NotNull(update, "SetUp failed");
 
             var eventData = await listener.WaitFirstEventWithTimeoutAsync<EventResultInfo>(

--- a/src/HassClient.WS/HassClient.WS.csproj
+++ b/src/HassClient.WS/HassClient.WS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.15</Version>
+    <Version>2.0.0</Version>
     <Authors>VFerrer</Authors>
     <Description>A Home Assistant WebSocket client to communicate with Home Assistant instances.</Description>
     <RepositoryUrl>https://github.com/vicfergar/HassClient</RepositoryUrl>

--- a/src/HassClient.WS/Messages/Commands/EntitySourceMessage.cs
+++ b/src/HassClient.WS/Messages/Commands/EntitySourceMessage.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace HassClient.WS.Messages
+﻿namespace HassClient.WS.Messages
 {
     internal class EntitySourceMessage : BaseOutgoingMessage
     {

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/AreaRegistryMessagesFactory.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/AreaRegistryMessagesFactory.cs
@@ -12,19 +12,19 @@ namespace HassClient.WS.Messages
         {
         }
 
-        public new BaseOutgoingMessage CreateCreateMessage(Area area)
+        public new BaseOutgoingMessage BuildCreateMessage(Area area)
         {
-            return base.CreateCreateMessage(area);
+            return base.BuildCreateMessage(area);
         }
 
-        public new BaseOutgoingMessage CreateUpdateMessage(Area area, bool forceUpdate)
+        public new BaseOutgoingMessage BuildUpdateMessage(Area area, bool forceUpdate)
         {
-            return base.CreateUpdateMessage(area, forceUpdate);
+            return base.BuildUpdateMessage(area, forceUpdate);
         }
 
-        public BaseOutgoingMessage CreateDeleteMessage(Area area)
+        public BaseOutgoingMessage BuildDeleteMessage(Area area)
         {
-            return base.CreateDeleteMessage(area);
+            return base.BuildDeleteMessage(area);
         }
     }
 }

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/CategoryRegistryMessagesFactory.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/CategoryRegistryMessagesFactory.cs
@@ -12,24 +12,24 @@ namespace HassClient.WS.Messages
         {
         }
 
-        public BaseOutgoingMessage CreateListMessage(string scope)
+        public BaseOutgoingMessage BuildListMessage(string scope)
         {
-            return this.CreateListMessage(mergedObject: new { scope });
+            return this.BuildListMessage(mergedObject: new { scope });
         }
 
-        public new BaseOutgoingMessage CreateCreateMessage(Category category)
+        public new BaseOutgoingMessage BuildCreateMessage(Category category)
         {
-            return base.CreateCreateMessage(category);
+            return base.BuildCreateMessage(category);
         }
 
-        public new BaseOutgoingMessage CreateUpdateMessage(Category category, bool forceUpdate)
+        public new BaseOutgoingMessage BuildUpdateMessage(Category category, bool forceUpdate)
         {
-            return base.CreateUpdateMessage(category, forceUpdate);
+            return base.BuildUpdateMessage(category, forceUpdate);
         }
 
-        public BaseOutgoingMessage CreateDeleteMessage(Category category)
+        public BaseOutgoingMessage BuildDeleteMessage(Category category)
         {
-            return this.CreateDeleteMessage(category, mergedObject: new { category.Scope });
+            return this.BuildDeleteMessage(category, mergedObject: new { category.Scope });
         }
     }
 }

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/DeviceRegistryMessagesFactory.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/DeviceRegistryMessagesFactory.cs
@@ -13,9 +13,9 @@ namespace HassClient.WS.Messages
         {
         }
 
-        public BaseOutgoingMessage CreateUpdateMessage(Device device, bool? disable, bool forceUpdate)
+        public BaseOutgoingMessage BuildUpdateMessage(Device device, bool? disable, bool forceUpdate)
         {
-            var model = this.CreateDefaultUpdateObject(device, forceUpdate);
+            var model = this.BuildDefaultUpdateObject(device, forceUpdate);
 
             if (disable.HasValue)
             {
@@ -23,7 +23,7 @@ namespace HassClient.WS.Messages
                 model.Merge(merged);
             }
 
-            return this.CreateUpdateMessage(device.Id, model);
+            return this.BuildUpdateMessage(device.Id, model);
         }
     }
 }

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/EntityRegistryMessagesFactory.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/EntityRegistryMessagesFactory.cs
@@ -13,15 +13,15 @@ namespace HassClient.WS.Messages
         {
         }
 
-        public BaseOutgoingMessage CreateGetMessage(string entityId)
+        public BaseOutgoingMessage BuildGetMessage(string entityId)
         {
-            return this.CreateCustomOperationMessage("get", entityId);
+            return this.BuildCustomOperationMessage("get", entityId);
         }
 
-        public BaseOutgoingMessage CreateUpdateMessage(EntityRegistryEntry entity, string newEntityId, bool? disable, bool forceUpdate)
+        public BaseOutgoingMessage BuildUpdateMessage(EntityRegistryEntry entity, string newEntityId, bool? disable, bool forceUpdate)
         {
             var shouldForceUpdate = !entity.SupportsPartialUpdates || forceUpdate;
-            var model = this.CreateDefaultUpdateObject(entity, shouldForceUpdate);
+            var model = this.BuildDefaultUpdateObject(entity, shouldForceUpdate);
 
             if (newEntityId != null)
             {
@@ -35,12 +35,12 @@ namespace HassClient.WS.Messages
                 model.Merge(merged);
             }
 
-            return this.CreateUpdateMessage(entity.EntityId, model);
+            return this.BuildUpdateMessage(entity.EntityId, model);
         }
 
-        public BaseOutgoingMessage CreateDeleteMessage(EntityRegistryEntry entity)
+        public BaseOutgoingMessage BuildDeleteMessage(EntityRegistryEntry entity)
         {
-            return this.CreateCustomOperationMessage("remove", entity.EntityId);
+            return this.BuildCustomOperationMessage("remove", entity.EntityId);
         }
     }
 }

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/FloorRegistryMessagesFactory.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/FloorRegistryMessagesFactory.cs
@@ -12,19 +12,19 @@ namespace HassClient.WS.Messages
         {
         }
 
-        public new BaseOutgoingMessage CreateCreateMessage(Floor floor)
+        public new BaseOutgoingMessage BuildCreateMessage(Floor floor)
         {
-            return base.CreateCreateMessage(floor);
+            return base.BuildCreateMessage(floor);
         }
 
-        public new BaseOutgoingMessage CreateUpdateMessage(Floor floor, bool forceUpdate)
+        public new BaseOutgoingMessage BuildUpdateMessage(Floor floor, bool forceUpdate)
         {
-            return base.CreateUpdateMessage(floor, forceUpdate);
+            return base.BuildUpdateMessage(floor, forceUpdate);
         }
 
-        public BaseOutgoingMessage CreateDeleteMessage(Floor floor)
+        public BaseOutgoingMessage BuildDeleteMessage(Floor floor)
         {
-            return base.CreateDeleteMessage(floor);
+            return base.BuildDeleteMessage(floor);
         }
     }
 }

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/LabelRegistryMessagesFactory.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/LabelRegistryMessagesFactory.cs
@@ -12,19 +12,19 @@ namespace HassClient.WS.Messages
         {
         }
 
-        public new BaseOutgoingMessage CreateCreateMessage(Label label)
+        public new BaseOutgoingMessage BuildCreateMessage(Label label)
         {
-            return base.CreateCreateMessage(label);
+            return base.BuildCreateMessage(label);
         }
 
-        public new BaseOutgoingMessage CreateUpdateMessage(Label label, bool forceUpdate)
+        public new BaseOutgoingMessage BuildUpdateMessage(Label label, bool forceUpdate)
         {
-            return base.CreateUpdateMessage(label, forceUpdate);
+            return base.BuildUpdateMessage(label, forceUpdate);
         }
 
-        public BaseOutgoingMessage CreateDeleteMessage(Label label)
+        public BaseOutgoingMessage BuildDeleteMessage(Label label)
         {
-            return base.CreateDeleteMessage(label);
+            return base.BuildDeleteMessage(label);
         }
     }
 }

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/RegistryEntryCollectionMessagesFactory`1.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/RegistryEntryCollectionMessagesFactory`1.cs
@@ -54,43 +54,43 @@ namespace HassClient.WS.Messages.Commands
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to request the list of registered items.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to request the list of registered items.
         /// </summary>
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to request the list of registered items.
         /// </returns>
-        public BaseOutgoingMessage CreateListMessage()
+        public BaseOutgoingMessage BuildListMessage()
         {
-            return this.CreateListMessage(mergedObject: null);
+            return this.BuildListMessage(mergedObject: null);
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to add a new item in the collection registry.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to add a new item in the collection registry.
         /// </summary>
         /// <param name="mergedObject">Object containing additional fields that will be merged to the create message.</param>
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to add a new item in the collection registry.
         /// </returns>
-        protected BaseOutgoingMessage CreateListMessage(object mergedObject = null)
+        protected BaseOutgoingMessage BuildListMessage(object mergedObject = null)
         {
             return new RawCommandMessage($"{this.apiPrefix}/list", mergedObject);
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to add a new item in the collection
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to add a new item in the collection
         /// registry filtering modifiable properties only.
         /// </summary>
         /// <param name="model">The model for the generation of the message.</param>
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to add a new item in the collection registry.
         /// </returns>
-        protected BaseOutgoingMessage CreateCreateMessage(TModel model)
+        protected BaseOutgoingMessage BuildCreateMessage(TModel model)
         {
-            return this.CreateCreateMessage(this.CreateDefaultCreateObject(model));
+            return this.BuildCreateMessage(this.BuildDefaultCreateObject(model));
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to update an existing item from
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to update an existing item from
         /// the collection registry filtering modified properties only.
         /// </summary>
         /// <param name="model">The model for the generation of the message.</param>
@@ -100,26 +100,26 @@ namespace HassClient.WS.Messages.Commands
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to update an existing item from the collection registry.
         /// </returns>
-        protected BaseOutgoingMessage CreateUpdateMessage(TModel model, bool forceUpdate)
+        protected BaseOutgoingMessage BuildUpdateMessage(TModel model, bool forceUpdate)
         {
-            return this.CreateUpdateMessage(model.UniqueId, this.CreateDefaultUpdateObject(model, forceUpdate));
+            return this.BuildUpdateMessage(model.UniqueId, this.BuildDefaultUpdateObject(model, forceUpdate));
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to delete an existing item from the collection registry.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to delete an existing item from the collection registry.
         /// </summary>
         /// <param name="model">The model for the generation of the message.</param>
         /// <param name="mergedObject">Object containing additional fields that will be merged to the delete message.</param>
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to delete an existing item from the collection registry.
         /// </returns>
-        protected BaseOutgoingMessage CreateDeleteMessage(TModel model, object mergedObject = null)
+        protected BaseOutgoingMessage BuildDeleteMessage(TModel model, object mergedObject = null)
         {
-            return this.CreateDeleteMessage(model.UniqueId, mergedObject);
+            return this.BuildDeleteMessage(model.UniqueId, mergedObject);
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to add a new item in the collection registry.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to add a new item in the collection registry.
         /// </summary>
         /// <param name="model">The object model to be added.</param>
         /// <param name="selectedProperties">White-list containing the name of the properties to extract from the <paramref name="model"/> object.
@@ -127,14 +127,14 @@ namespace HassClient.WS.Messages.Commands
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to add a new item in the collection registry.
         /// </returns>
-        protected BaseOutgoingMessage CreateCreateMessage(object model, IEnumerable<string> selectedProperties = null)
+        protected BaseOutgoingMessage BuildCreateMessage(object model, IEnumerable<string> selectedProperties = null)
         {
             var mergedObject = HassSerializer.CreateJObject(model, selectedProperties);
             return new RawCommandMessage($"{this.apiPrefix}/create", mergedObject);
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to update an existing item from the collection registry.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to update an existing item from the collection registry.
         /// </summary>
         /// <param name="modelId">The unique identifier of the collection registry item to update.</param>
         /// <param name="model">The object model to be updated.</param>
@@ -143,7 +143,7 @@ namespace HassClient.WS.Messages.Commands
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to update an existing item from the collection registry.
         /// </returns>
-        protected BaseOutgoingMessage CreateUpdateMessage(string modelId, object model, IEnumerable<string> selectedProperties = null)
+        protected BaseOutgoingMessage BuildUpdateMessage(string modelId, object model, IEnumerable<string> selectedProperties = null)
         {
             var mergedObject = HassSerializer.CreateJObject(model, selectedProperties);
             this.AddModelIdProperty(mergedObject, modelId);
@@ -151,14 +151,14 @@ namespace HassClient.WS.Messages.Commands
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to delete an existing item from the collection registry.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to delete an existing item from the collection registry.
         /// </summary>
         /// <param name="modelId">The unique identifier of the collection registry item to delete.</param>
         /// <param name="mergedObject">Object containing additional fields that will be merged to the delete message.</param>
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to delete an existing item from the collection registry.
         /// </returns>
-        protected BaseOutgoingMessage CreateDeleteMessage(string modelId, object mergedObject = null)
+        protected BaseOutgoingMessage BuildDeleteMessage(string modelId, object mergedObject = null)
         {
             var mergedObjectWithModelId = mergedObject != null ? HassSerializer.CreateJObject(mergedObject) : new JObject();
             this.AddModelIdProperty(mergedObjectWithModelId, modelId);
@@ -166,7 +166,7 @@ namespace HassClient.WS.Messages.Commands
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used in specific operations for certain collection registry items.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used in specific operations for certain collection registry items.
         /// </summary>
         /// <param name="customOpName">The custom operation name.</param>
         /// <param name="modelId">The unique identifier of the collection registry item.</param>
@@ -174,7 +174,7 @@ namespace HassClient.WS.Messages.Commands
         /// <param name="selectedProperties">White-list containing the name of the properties to extract from the <paramref name="model"/> object.
         /// When <see langword="null"/>, no filter will be applied.</param>
         /// <returns>A <see cref="BaseOutgoingMessage"/> used in specific operations for certain collection registry items.</returns>
-        protected BaseOutgoingMessage CreateCustomOperationMessage(string customOpName, string modelId, TModel model = null, IEnumerable<string> selectedProperties = null)
+        protected BaseOutgoingMessage BuildCustomOperationMessage(string customOpName, string modelId, TModel model = null, IEnumerable<string> selectedProperties = null)
         {
             var mergedObject = model != null ? HassSerializer.CreateJObject(model, selectedProperties) : new JObject();
             this.AddModelIdProperty(mergedObject, modelId);
@@ -182,24 +182,24 @@ namespace HassClient.WS.Messages.Commands
         }
 
         /// <summary>
-        /// Creates the default create object filtering modifiable property names only.
+        /// Builds the default create object filtering modifiable property names only.
         /// </summary>
         /// <param name="model">The object model to be updated.</param>
         /// <returns>The default create object filtering modifiable property names only.</returns>
-        protected JObject CreateDefaultCreateObject(TModel model)
+        protected JObject BuildDefaultCreateObject(TModel model)
         {
             return HassSerializer.CreateJObject(model, model.GetModifiablePropertyNames());
         }
 
         /// <summary>
-        /// Creates the default update object filtering modified property names only.
+        /// Builds the default update object filtering modified property names only.
         /// </summary>
         /// <param name="model">The object model to be updated.</param>
         /// <param name="forceUpdate">
         /// Indicates if the update message force the update of every modifiable property.
         /// </param>
         /// <returns>The default update object filtering modified property names only.</returns>
-        protected JObject CreateDefaultUpdateObject(TModel model, bool forceUpdate)
+        protected JObject BuildDefaultUpdateObject(TModel model, bool forceUpdate)
         {
             var selectedProperties = forceUpdate ? model.GetModifiablePropertyNames() : model.GetModifiedPropertyNames();
             return HassSerializer.CreateJObject(model, selectedProperties);

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/StorageCollectionMessagesFactory`1.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/StorageCollectionMessagesFactory`1.cs
@@ -44,19 +44,19 @@ namespace HassClient.WS.Messages
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to add a new registry entry in the storage collection.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to add a new registry entry in the storage collection.
         /// </summary>
         /// <param name="entry">The storage collection entry.</param>
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used to add a new registry entry in the storage collection.
         /// </returns>
-        public new BaseOutgoingMessage CreateCreateMessage(TStorageEntity entry)
+        public new BaseOutgoingMessage BuildCreateMessage(TStorageEntity entry)
         {
-            return base.CreateCreateMessage(entry);
+            return base.BuildCreateMessage(entry);
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to update an existing registry entry in the storage collection.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to update an existing registry entry in the storage collection.
         /// </summary>
         /// <param name="entry">The storage collection entry.</param>
         /// <param name="forceUpdate">
@@ -66,22 +66,22 @@ namespace HassClient.WS.Messages
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used update an existing registry entry in the storage collection.
         /// </returns>
-        public new BaseOutgoingMessage CreateUpdateMessage(TStorageEntity entry, bool forceUpdate)
+        public new BaseOutgoingMessage BuildUpdateMessage(TStorageEntity entry, bool forceUpdate)
         {
             var shouldForceUpdate = !entry.SupportsPartialUpdates || forceUpdate;
-            return base.CreateUpdateMessage(entry, shouldForceUpdate);
+            return base.BuildUpdateMessage(entry, shouldForceUpdate);
         }
 
         /// <summary>
-        /// Creates a <see cref="BaseOutgoingMessage"/> used to delete an existing registry entry from the storage collection.
+        /// Builds a <see cref="BaseOutgoingMessage"/> used to delete an existing registry entry from the storage collection.
         /// </summary>
         /// <param name="entry">The storage collection entry.</param>
         /// <returns>
         /// A <see cref="BaseOutgoingMessage"/> used delete an existing registry entry from the storage collection.
         /// </returns>
-        public BaseOutgoingMessage CreateDeleteMessage(TStorageEntity entry)
+        public BaseOutgoingMessage BuildDeleteMessage(TStorageEntity entry)
         {
-            return base.CreateDeleteMessage(entry);
+            return base.BuildDeleteMessage(entry);
         }
     }
 }

--- a/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/UserMessagesFactory.cs
+++ b/src/HassClient.WS/Messages/Commands/RegistryEntryCollections/UserMessagesFactory.cs
@@ -12,19 +12,19 @@ namespace HassClient.WS.Messages
         {
         }
 
-        public new BaseOutgoingMessage CreateCreateMessage(User user)
+        public new BaseOutgoingMessage BuildCreateMessage(User user)
         {
-            return base.CreateCreateMessage(user);
+            return base.BuildCreateMessage(user);
         }
 
-        public new BaseOutgoingMessage CreateUpdateMessage(User user, bool forceUpdate)
+        public new BaseOutgoingMessage BuildUpdateMessage(User user, bool forceUpdate)
         {
-            return base.CreateUpdateMessage(user, forceUpdate);
+            return base.BuildUpdateMessage(user, forceUpdate);
         }
 
-        public BaseOutgoingMessage CreateDeleteMessage(User user)
+        public BaseOutgoingMessage BuildDeleteMessage(User user)
         {
-            return base.CreateDeleteMessage(user);
+            return base.BuildDeleteMessage(user);
         }
     }
 }

--- a/src/HassClient.WS/Resources/AreasApi.cs
+++ b/src/HassClient.WS/Resources/AreasApi.cs
@@ -28,7 +28,7 @@ namespace HassClient.WS
         /// </returns>
         public Task<IEnumerable<Area>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateListMessage();
+            var commandMessage = AreaRegistryMessagesFactory.Instance.BuildListMessage();
             return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Area>>(commandMessage, cancellationToken);
         }
 
@@ -45,7 +45,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> CreateAsync(Area area, CancellationToken cancellationToken = default)
         {
-            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateCreateMessage(area);
+            var commandMessage = AreaRegistryMessagesFactory.Instance.BuildCreateMessage(area);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -71,7 +71,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> UpdateAsync(Area area, bool forceUpdate = false, CancellationToken cancellationToken = default)
         {
-            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateUpdateMessage(area, forceUpdate);
+            var commandMessage = AreaRegistryMessagesFactory.Instance.BuildUpdateMessage(area, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -94,7 +94,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> DeleteAsync(Area area, CancellationToken cancellationToken = default)
         {
-            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateDeleteMessage(area);
+            var commandMessage = AreaRegistryMessagesFactory.Instance.BuildDeleteMessage(area);
             var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
             if (success)
             {

--- a/src/HassClient.WS/Resources/AreasApi.cs
+++ b/src/HassClient.WS/Resources/AreasApi.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing areas in Home Assistant.
+    /// </summary>
+    public class AreasApi : ResourceApi
+    {
+        internal AreasApi(HassClientWebSocket webSocket)
+            : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered <see cref="Area"/> in the Home Assistant instance.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered <see cref="Area"/> in the Home Assistant instance.
+        /// </returns>
+        public Task<IEnumerable<Area>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateListMessage();
+            return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Area>>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Area"/>.
+        /// </summary>
+        /// <param name="area">The <see cref="Area"/> with the new values.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// create operation was successfully done.
+        /// </returns>
+        public async Task<bool> CreateAsync(Area area, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateCreateMessage(area);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(area);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Updates an existing <see cref="Area"/>.
+        /// </summary>
+        /// <param name="area">The <see cref="Area"/> with the new values.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync(Area area, bool forceUpdate = false, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateUpdateMessage(area, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(area);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Deletes an existing <see cref="Area"/>.
+        /// </summary>
+        /// <param name="area">The <see cref="Area"/> to delete.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// delete operation was successfully done.
+        /// </returns>
+        public async Task<bool> DeleteAsync(Area area, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = AreaRegistryMessagesFactory.Instance.CreateDeleteMessage(area);
+            var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
+            if (success)
+            {
+                area.Untrack();
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/CategoriesApi.cs
+++ b/src/HassClient.WS/Resources/CategoriesApi.cs
@@ -29,7 +29,7 @@ namespace HassClient.WS
         /// </returns>
         public Task<IEnumerable<Category>> ListAsync(string scope, CancellationToken cancellationToken = default)
         {
-            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateListMessage(scope);
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.BuildListMessage(scope);
             return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Category>>(commandMessage, cancellationToken);
         }
 
@@ -46,7 +46,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> CreateAsync(Category category, CancellationToken cancellationToken = default)
         {
-            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateCreateMessage(category);
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.BuildCreateMessage(category);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -72,7 +72,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> UpdateAsync(Category category, bool forceUpdate = false, CancellationToken cancellationToken = default)
         {
-            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateUpdateMessage(category, forceUpdate);
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.BuildUpdateMessage(category, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -95,7 +95,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> DeleteAsync(Category category, CancellationToken cancellationToken = default)
         {
-            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateDeleteMessage(category);
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.BuildDeleteMessage(category);
             var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
             if (success)
             {

--- a/src/HassClient.WS/Resources/CategoriesApi.cs
+++ b/src/HassClient.WS/Resources/CategoriesApi.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing categories in Home Assistant.
+    /// </summary>
+    public class CategoriesApi : ResourceApi
+    {
+        internal CategoriesApi(HassClientWebSocket webSocket)
+            : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered <see cref="Category"/> in the Home Assistant instance.
+        /// </summary>
+        /// <param name="scope">The scope of the categories to retrieve.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered <see cref="Category"/> in the Home Assistant instance.
+        /// </returns>
+        public Task<IEnumerable<Category>> ListAsync(string scope, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateListMessage(scope);
+            return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Category>>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Category"/>.
+        /// </summary>
+        /// <param name="category">The <see cref="Category"/> with the new values.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// create operation was successfully done.
+        /// </returns>
+        public async Task<bool> CreateAsync(Category category, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateCreateMessage(category);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(category);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Updates an existing <see cref="Category"/>.
+        /// </summary>
+        /// <param name="category">The <see cref="Category"/> with the new values.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync(Category category, bool forceUpdate = false, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateUpdateMessage(category, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(category);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Deletes an existing <see cref="Category"/>.
+        /// </summary>
+        /// <param name="category">The <see cref="Category"/> to delete.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// delete operation was successfully done.
+        /// </returns>
+        public async Task<bool> DeleteAsync(Category category, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = CategoryRegistryMessagesFactory.Instance.CreateDeleteMessage(category);
+            var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
+            if (success)
+            {
+                category.Untrack();
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/DevicesApi.cs
+++ b/src/HassClient.WS/Resources/DevicesApi.cs
@@ -28,7 +28,7 @@ namespace HassClient.WS
         /// </returns>
         public Task<IEnumerable<Device>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var commandMessage = DeviceRegistryMessagesFactory.Instance.CreateListMessage();
+            var commandMessage = DeviceRegistryMessagesFactory.Instance.BuildListMessage();
             return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Device>>(commandMessage, cancellationToken);
         }
 
@@ -49,7 +49,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> UpdateAsync(Device device, bool? disable = null, bool forceUpdate = false, CancellationToken cancellationToken = default)
         {
-            var commandMessage = DeviceRegistryMessagesFactory.Instance.CreateUpdateMessage(device, disable, forceUpdate);
+            var commandMessage = DeviceRegistryMessagesFactory.Instance.BuildUpdateMessage(device, disable, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {

--- a/src/HassClient.WS/Resources/DevicesApi.cs
+++ b/src/HassClient.WS/Resources/DevicesApi.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing devices in Home Assistant.
+    /// </summary>
+    public class DevicesApi : ResourceApi
+    {
+        internal DevicesApi(HassClientWebSocket webSocket)
+            : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered <see cref="Device"/> in the Home Assistant instance.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered <see cref="Device"/> in the Home Assistant instance.
+        /// </returns>
+        public Task<IEnumerable<Device>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var commandMessage = DeviceRegistryMessagesFactory.Instance.CreateListMessage();
+            return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Device>>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Updates an existing <see cref="Device"/>.
+        /// </summary>
+        /// <param name="device">The <see cref="Device"/> with the new values.</param>
+        /// <param name="disable">If not <see langword="null"/>, it will enable or disable the entity.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync(Device device, bool? disable = null, bool forceUpdate = false, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = DeviceRegistryMessagesFactory.Instance.CreateUpdateMessage(device, disable, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(device);
+            }
+
+            return result.Success;
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/EntitiesEntriesApi.cs
+++ b/src/HassClient.WS/Resources/EntitiesEntriesApi.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.Serialization;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing entity registry entries in Home Assistant.
+    /// </summary>
+    public class EntitiesEntriesApi : ResourceApi
+    {
+        internal EntitiesEntriesApi(HassClientWebSocket webSocket)
+            : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered entity in the Home Assistant instance.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered entity in the Home Assistant instance.
+        /// </returns>
+        public Task<IEnumerable<EntityRegistryEntry>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateListMessage();
+            return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<EntityRegistryEntry>>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets a specific entity registry entry by its entity ID.
+        /// </summary>
+        /// <param name="entityId">The entity ID to retrieve.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is the <see cref="EntityRegistryEntry"/>.
+        /// </returns>
+        public Task<EntityRegistryEntry> GetAsync(string entityId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(entityId))
+            {
+                throw new ArgumentException($"'{nameof(entityId)}' cannot be null or empty", nameof(entityId));
+            }
+
+            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateGetMessage(entityId);
+            return this.HassClientWebSocket.SendCommandWithResultAsync<EntityRegistryEntry>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Refresh a given <see cref="EntityRegistryEntry"/> with the values from the server.
+        /// </summary>
+        /// <param name="entityRegistryEntry">The entity registry entry to refresh.</param>
+        /// <param name="newEntityId">If not <see langword="null"/>, it will be used as entity id.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// refresh operation was successfully done.
+        /// </returns>
+        public async Task<bool> RefreshAsync(EntityRegistryEntry entityRegistryEntry, string newEntityId = null, CancellationToken cancellationToken = default)
+        {
+            var entityId = newEntityId ?? entityRegistryEntry.EntityId;
+            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateGetMessage(entityId);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (!result.Success)
+            {
+                return false;
+            }
+
+            result.PopulateResult(entityRegistryEntry);
+            return true;
+        }
+
+        /// <summary>
+        /// Updates an existing entity registry entry.
+        /// </summary>
+        /// <param name="entity">The entity registry entry with the updated values.</param>
+        /// <param name="newEntityId">If not null, it will update the current entity ID.</param>
+        /// <param name="disable">If not null, it will enable or disable the entity.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync(
+            EntityRegistryEntry entity,
+            string newEntityId = null,
+            bool? disable = null,
+            bool forceUpdate = false,
+            CancellationToken cancellationToken = default)
+        {
+            if (newEntityId == entity.EntityId)
+            {
+                throw new ArgumentException($"{nameof(newEntityId)} cannot be the same as {nameof(entity.EntityId)}");
+            }
+
+            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateUpdateMessage(entity, newEntityId, disable, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync<EntityEntryResponse>(commandMessage, cancellationToken);
+            if (result == null)
+            {
+                return false;
+            }
+
+            HassSerializer.PopulateObject(result.EntityEntryRaw, entity);
+            return true;
+        }
+
+        /// <summary>
+        /// Deletes an existing entity registry entry.
+        /// </summary>
+        /// <param name="entity">The entity registry entry to delete.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// delete operation was successfully done.
+        /// </returns>
+        public async Task<bool> DeleteAsync(EntityRegistryEntry entity, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateDeleteMessage(entity);
+            var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
+            if (success)
+            {
+                entity.Untrack();
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/EntitiesEntriesApi.cs
+++ b/src/HassClient.WS/Resources/EntitiesEntriesApi.cs
@@ -30,7 +30,7 @@ namespace HassClient.WS
         /// </returns>
         public Task<IEnumerable<EntityRegistryEntry>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateListMessage();
+            var commandMessage = EntityRegistryMessagesFactory.Instance.BuildListMessage();
             return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<EntityRegistryEntry>>(commandMessage, cancellationToken);
         }
 
@@ -51,7 +51,7 @@ namespace HassClient.WS
                 throw new ArgumentException($"'{nameof(entityId)}' cannot be null or empty", nameof(entityId));
             }
 
-            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateGetMessage(entityId);
+            var commandMessage = EntityRegistryMessagesFactory.Instance.BuildGetMessage(entityId);
             return this.HassClientWebSocket.SendCommandWithResultAsync<EntityRegistryEntry>(commandMessage, cancellationToken);
         }
 
@@ -70,7 +70,7 @@ namespace HassClient.WS
         public async Task<bool> RefreshAsync(EntityRegistryEntry entityRegistryEntry, string newEntityId = null, CancellationToken cancellationToken = default)
         {
             var entityId = newEntityId ?? entityRegistryEntry.EntityId;
-            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateGetMessage(entityId);
+            var commandMessage = EntityRegistryMessagesFactory.Instance.BuildGetMessage(entityId);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (!result.Success)
             {
@@ -109,7 +109,7 @@ namespace HassClient.WS
                 throw new ArgumentException($"{nameof(newEntityId)} cannot be the same as {nameof(entity.EntityId)}");
             }
 
-            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateUpdateMessage(entity, newEntityId, disable, forceUpdate);
+            var commandMessage = EntityRegistryMessagesFactory.Instance.BuildUpdateMessage(entity, newEntityId, disable, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync<EntityEntryResponse>(commandMessage, cancellationToken);
             if (result == null)
             {
@@ -133,7 +133,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> DeleteAsync(EntityRegistryEntry entity, CancellationToken cancellationToken = default)
         {
-            var commandMessage = EntityRegistryMessagesFactory.Instance.CreateDeleteMessage(entity);
+            var commandMessage = EntityRegistryMessagesFactory.Instance.BuildDeleteMessage(entity);
             var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
             if (success)
             {

--- a/src/HassClient.WS/Resources/FloorsApi.cs
+++ b/src/HassClient.WS/Resources/FloorsApi.cs
@@ -28,7 +28,7 @@ namespace HassClient.WS
         /// </returns>
         public Task<IEnumerable<Floor>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateListMessage();
+            var commandMessage = FloorRegistryMessagesFactory.Instance.BuildListMessage();
             return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Floor>>(commandMessage, cancellationToken);
         }
 
@@ -45,7 +45,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> CreateAsync(Floor floor, CancellationToken cancellationToken = default)
         {
-            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateCreateMessage(floor);
+            var commandMessage = FloorRegistryMessagesFactory.Instance.BuildCreateMessage(floor);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -71,7 +71,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> UpdateAsync(Floor floor, bool forceUpdate = false, CancellationToken cancellationToken = default)
         {
-            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateUpdateMessage(floor, forceUpdate);
+            var commandMessage = FloorRegistryMessagesFactory.Instance.BuildUpdateMessage(floor, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -94,7 +94,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> DeleteAsync(Floor floor, CancellationToken cancellationToken = default)
         {
-            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateDeleteMessage(floor);
+            var commandMessage = FloorRegistryMessagesFactory.Instance.BuildDeleteMessage(floor);
             var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
             if (success)
             {

--- a/src/HassClient.WS/Resources/FloorsApi.cs
+++ b/src/HassClient.WS/Resources/FloorsApi.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing floors in Home Assistant.
+    /// </summary>
+    public class FloorsApi : ResourceApi
+    {
+        internal FloorsApi(HassClientWebSocket hassClientWebSocket)
+            : base(hassClientWebSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered <see cref="Floor"/> in the Home Assistant instance.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered <see cref="Floor"/> in the Home Assistant instance.
+        /// </returns>
+        public Task<IEnumerable<Floor>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateListMessage();
+            return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Floor>>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Floor"/>.
+        /// </summary>
+        /// <param name="floor">The <see cref="Floor"/> with the new values.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// create operation was successfully done.
+        /// </returns>
+        public async Task<bool> CreateAsync(Floor floor, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateCreateMessage(floor);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(floor);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Updates an existing <see cref="Floor"/>.
+        /// </summary>
+        /// <param name="floor">The <see cref="Floor"/> with the new values.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync(Floor floor, bool forceUpdate = false, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateUpdateMessage(floor, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(floor);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Deletes an existing <see cref="Floor"/>.
+        /// </summary>
+        /// <param name="floor">The <see cref="Floor"/> to delete.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// delete operation was successfully done.
+        /// </returns>
+        public async Task<bool> DeleteAsync(Floor floor, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = FloorRegistryMessagesFactory.Instance.CreateDeleteMessage(floor);
+            var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
+            if (success)
+            {
+                floor.Untrack();
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/LabelsApi.cs
+++ b/src/HassClient.WS/Resources/LabelsApi.cs
@@ -28,7 +28,7 @@ namespace HassClient.WS
         /// </returns>
         public Task<IEnumerable<Label>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateListMessage();
+            var commandMessage = LabelRegistryMessagesFactory.Instance.BuildListMessage();
             return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Label>>(commandMessage, cancellationToken);
         }
 
@@ -45,7 +45,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> CreateAsync(Label label, CancellationToken cancellationToken = default)
         {
-            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateCreateMessage(label);
+            var commandMessage = LabelRegistryMessagesFactory.Instance.BuildCreateMessage(label);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -71,7 +71,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> UpdateAsync(Label label, bool forceUpdate = false, CancellationToken cancellationToken = default)
         {
-            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateUpdateMessage(label, forceUpdate);
+            var commandMessage = LabelRegistryMessagesFactory.Instance.BuildUpdateMessage(label, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -94,7 +94,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> DeleteAsync(Label label, CancellationToken cancellationToken = default)
         {
-            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateDeleteMessage(label);
+            var commandMessage = LabelRegistryMessagesFactory.Instance.BuildDeleteMessage(label);
             var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
             if (success)
             {

--- a/src/HassClient.WS/Resources/LabelsApi.cs
+++ b/src/HassClient.WS/Resources/LabelsApi.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing labels in Home Assistant.
+    /// </summary>
+    public class LabelsApi : ResourceApi
+    {
+        internal LabelsApi(HassClientWebSocket webSocket)
+            : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered <see cref="Label"/> in the Home Assistant instance.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered <see cref="Label"/> in the Home Assistant instance.
+        /// </returns>
+        public Task<IEnumerable<Label>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateListMessage();
+            return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<Label>>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Label"/>.
+        /// </summary>
+        /// <param name="label">The <see cref="Label"/> with the new values.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// create operation was successfully done.
+        /// </returns>
+        public async Task<bool> CreateAsync(Label label, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateCreateMessage(label);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(label);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Updates an existing <see cref="Label"/>.
+        /// </summary>
+        /// <param name="label">The <see cref="Label"/> with the new values.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync(Label label, bool forceUpdate = false, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateUpdateMessage(label, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(label);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Deletes an existing <see cref="Label"/>.
+        /// </summary>
+        /// <param name="label">The <see cref="Label"/> to delete.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// delete operation was successfully done.
+        /// </returns>
+        public async Task<bool> DeleteAsync(Label label, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = LabelRegistryMessagesFactory.Instance.CreateDeleteMessage(label);
+            var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
+            if (success)
+            {
+                label.Untrack();
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/ResourceApi.cs
+++ b/src/HassClient.WS/Resources/ResourceApi.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents a base class for API groups.
+    /// </summary>
+    public abstract class ResourceApi
+    {
+        /// <summary>
+        /// The WebSocket client used to communicate with the Home Assistant instance.
+        /// </summary>
+        protected readonly HassClientWebSocket HassClientWebSocket;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceApi"/> class.
+        /// </summary>
+        /// <param name="hassClientWebSocket">The WebSocket client used to communicate with the Home Assistant instance.</param>
+        protected ResourceApi(HassClientWebSocket hassClientWebSocket)
+        {
+            this.HassClientWebSocket = hassClientWebSocket ?? throw new ArgumentNullException(nameof(hassClientWebSocket));
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/ServicesApi.cs
+++ b/src/HassClient.WS/Resources/ServicesApi.cs
@@ -1,0 +1,167 @@
+﻿using HassClient.Helpers;
+using HassClient.Models;
+using HassClient.Serialization;
+using HassClient.WS.Messages;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Api to manage services in Home Assistant.
+    /// </summary>
+    public class ServicesApi : ResourceApi
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServicesApi"/> class.
+        /// </summary>
+        /// <param name="webSocket">The websocket client instance.</param>
+        public ServicesApi(HassClientWebSocket webSocket)
+            : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection of <see cref="ServiceDomain"/> of every registered service in the Home Assistant instance.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection of
+        /// <see cref="ServiceDomain"/> of every registered service in the Home Assistant instance.
+        /// </returns>
+        public async Task<IEnumerable<ServiceDomain>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var commandMessage = new GetServicesMessage();
+            var dict = await this.HassClientWebSocket.SendCommandWithResultAsync<Dictionary<string, JRaw>>(commandMessage, cancellationToken);
+            return dict?.Select(x =>
+                new ServiceDomain()
+                {
+                    Domain = x.Key,
+                    Services = HassSerializer.DeserializeObject<Dictionary<string, Service>>(x.Value),
+                });
+        }
+
+        /// <summary>
+        /// Calls a service within a specific domain.
+        /// </summary>
+        /// <param name="domain">The service domain.</param>
+        /// <param name="service">The service to call.</param>
+        /// <param name="data">The optional data to use in the service invocation.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a <see cref="Context"/>
+        /// associated with the result of the service invocation.
+        /// </returns>
+        public async Task<Context> CallAsync(string domain, string service, object data = null, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = new CallServiceMessage(domain, service, data);
+            var state = await this.HassClientWebSocket.SendCommandWithResultAsync<StateModel>(commandMessage, cancellationToken);
+            return state?.Context;
+        }
+
+        /// <summary>
+        /// Calls a service within a specific domain.
+        /// </summary>
+        /// <param name="domain">The service domain.</param>
+        /// <param name="service">The service to call.</param>
+        /// <param name="data">The optional data to use in the service invocation.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// service invocation was successfully done.
+        /// </returns>
+        public async Task<bool> CallAsync(KnownDomains domain, KnownServices service, object data = null, CancellationToken cancellationToken = default)
+        {
+            var context = await this.CallAsync(domain.ToDomainString(), service.ToServiceString(), data, cancellationToken);
+            return context != null;
+        }
+
+        /// <summary>
+        /// Calls a service within a specific domain targeting specific entities.
+        /// <para>
+        /// This overload is useful when only entity_id is needed in service invocation.
+        /// </para>
+        /// </summary>
+        /// <param name="domain">The service domain.</param>
+        /// <param name="service">The service to call.</param>
+        /// <param name="entityIds">The ids of the target entities affected by the service call.</param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// service invocation was successfully done.
+        /// </returns>
+        public Task<bool> CallForEntitiesAsync(string domain, string service, params string[] entityIds)
+        {
+            return this.CallForEntitiesAsync(domain, service, CancellationToken.None, entityIds);
+        }
+
+        /// <summary>
+        /// Calls a service within a specific domain targeting specific entities.
+        /// <para>
+        /// This overload is useful when only entity_id is needed in service invocation.
+        /// </para>
+        /// </summary>
+        /// <param name="domain">The service domain.</param>
+        /// <param name="service">The service to call.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <param name="entityIds">The ids of the target entities affected by the service call.</param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// service invocation was successfully done.
+        /// </returns>
+        public async Task<bool> CallForEntitiesAsync(string domain, string service, CancellationToken cancellationToken = default, params string[] entityIds)
+        {
+            var context = await this.CallAsync(domain, service, new { entity_id = entityIds }, cancellationToken);
+            return context != null;
+        }
+
+        /// <summary>
+        /// Calls a service within a specific domain targeting specific entities.
+        /// <para>
+        /// This overload is useful when only entity_id is needed in service invocation.
+        /// </para>
+        /// </summary>
+        /// <param name="domain">The service domain.</param>
+        /// <param name="service">The service to call.</param>
+        /// <param name="entityIds">The ids of the target entities affected by the service call.</param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// service invocation was successfully done.
+        /// </returns>
+        public Task<bool> CallForEntitiesAsync(KnownDomains domain, KnownServices service, params string[] entityIds)
+        {
+            return this.CallForEntitiesAsync(domain, service, CancellationToken.None, entityIds);
+        }
+
+        /// <summary>
+        /// Calls a service within a specific domain targeting specific entities.
+        /// <para>
+        /// This overload is useful when only entity_id is needed in service invocation.
+        /// </para>
+        /// </summary>
+        /// <param name="domain">The service domain.</param>
+        /// <param name="service">The service to call.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <param name="entityIds">The ids of the target entities affected by the service call.</param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// service invocation was successfully done.
+        /// </returns>
+        public Task<bool> CallForEntitiesAsync(KnownDomains domain, KnownServices service, CancellationToken cancellationToken = default, params string[] entityIds)
+        {
+            return this.CallAsync(domain, service, new { entity_id = entityIds }, cancellationToken);
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/StorageEntitiesApi.cs
+++ b/src/HassClient.WS/Resources/StorageEntitiesApi.cs
@@ -32,7 +32,7 @@ namespace HassClient.WS
         public async Task<IEnumerable<TStorageEntity>> ListAsync<TStorageEntity>(CancellationToken cancellationToken = default)
             where TStorageEntity : StorageEntityRegistryEntryBase
         {
-            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateListMessage();
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().BuildListMessage();
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -70,7 +70,7 @@ namespace HassClient.WS
         public async Task<bool> CreateAsync<TStorageEntity>(TStorageEntity storageEntity, CancellationToken cancellationToken = default)
             where TStorageEntity : StorageEntityRegistryEntryBase
         {
-            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateCreateMessage(storageEntity);
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().BuildCreateMessage(storageEntity);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -99,7 +99,7 @@ namespace HassClient.WS
         public async Task<bool> UpdateAsync<TStorageEntity>(TStorageEntity storageEntity, bool forceUpdate = false, CancellationToken cancellationToken = default)
             where TStorageEntity : StorageEntityRegistryEntryBase
         {
-            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateUpdateMessage(storageEntity, forceUpdate);
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().BuildUpdateMessage(storageEntity, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
             if (result.Success)
             {
@@ -124,7 +124,7 @@ namespace HassClient.WS
         public async Task<bool> DeleteAsync<TStorageEntity>(TStorageEntity storageEntity, CancellationToken cancellationToken = default)
             where TStorageEntity : StorageEntityRegistryEntryBase
         {
-            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateDeleteMessage(storageEntity);
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().BuildDeleteMessage(storageEntity);
             var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
             if (success)
             {

--- a/src/HassClient.WS/Resources/StorageEntitiesApi.cs
+++ b/src/HassClient.WS/Resources/StorageEntitiesApi.cs
@@ -1,0 +1,137 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing storage entity registry entries in Home Assistant.
+    /// </summary>
+    public class StorageEntitiesApi : ResourceApi
+    {
+        internal StorageEntitiesApi(HassClientWebSocket webSocket)
+         : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered storage entity registry entry of the given type
+        /// in the Home Assistant instance.
+        /// </summary>
+        /// <typeparam name="TStorageEntity">The storage entity registry entry type.</typeparam>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered <typeparamref name="TStorageEntity"/> entity in the Home Assistant instance.
+        /// </returns>
+        public async Task<IEnumerable<TStorageEntity>> ListAsync<TStorageEntity>(CancellationToken cancellationToken = default)
+            where TStorageEntity : StorageEntityRegistryEntryBase
+        {
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateListMessage();
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                if (typeof(TStorageEntity) == typeof(Person))
+                {
+                    var response = result.DeserializeResult<PersonResponse>();
+                    return response.Storage
+                                   .Select(person =>
+                                   {
+                                       person.IsStorageEntry = true;
+                                       return person;
+                                   })
+                                   .Concat(response.Config)
+                                   .Cast<TStorageEntity>();
+                }
+
+                return result.DeserializeResult<IEnumerable<TStorageEntity>>();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Creates a new storage entity registry entry of the given type.
+        /// </summary>
+        /// <typeparam name="TStorageEntity">The storage entity registry entry type.</typeparam>
+        /// <param name="storageEntity">The new storage entity registry entry.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// create operation was successfully done.
+        /// </returns>
+        public async Task<bool> CreateAsync<TStorageEntity>(TStorageEntity storageEntity, CancellationToken cancellationToken = default)
+            where TStorageEntity : StorageEntityRegistryEntryBase
+        {
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateCreateMessage(storageEntity);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(storageEntity);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Updates an existing storage entity registry entry of the given type.
+        /// </summary>
+        /// <typeparam name="TStorageEntity">The storage entity registry entry type.</typeparam>
+        /// <param name="storageEntity">The storage entity registry entry with the updated values.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property. If the entity
+        /// does not support partial updates, this parameter is ignored.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync<TStorageEntity>(TStorageEntity storageEntity, bool forceUpdate = false, CancellationToken cancellationToken = default)
+            where TStorageEntity : StorageEntityRegistryEntryBase
+        {
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateUpdateMessage(storageEntity, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync(commandMessage, cancellationToken);
+            if (result.Success)
+            {
+                result.PopulateResult(storageEntity);
+            }
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// Deletes an existing storage entity registry entry of the given type.
+        /// </summary>
+        /// <typeparam name="TStorageEntity">The storage entity registry entry type.</typeparam>
+        /// <param name="storageEntity">The storage entity registry entry to delete.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// delete operation was successfully done.
+        /// </returns>
+        public async Task<bool> DeleteAsync<TStorageEntity>(TStorageEntity storageEntity, CancellationToken cancellationToken = default)
+            where TStorageEntity : StorageEntityRegistryEntryBase
+        {
+            var commandMessage = StorageCollectionMessagesFactory<TStorageEntity>.Create().CreateDeleteMessage(storageEntity);
+            var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
+            if (success)
+            {
+                storageEntity.Untrack();
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/HassClient.WS/Resources/UsersApi.cs
+++ b/src/HassClient.WS/Resources/UsersApi.cs
@@ -29,7 +29,7 @@ namespace HassClient.WS
         /// </returns>
         public Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default)
         {
-            var commandMessage = UserMessagesFactory.Instance.CreateListMessage();
+            var commandMessage = UserMessagesFactory.Instance.BuildListMessage();
             return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<User>>(commandMessage, cancellationToken);
         }
 
@@ -46,7 +46,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> CreateAsync(User user, CancellationToken cancellationToken = default)
         {
-            var commandMessage = UserMessagesFactory.Instance.CreateCreateMessage(user);
+            var commandMessage = UserMessagesFactory.Instance.BuildCreateMessage(user);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync<UserResponse>(commandMessage, cancellationToken);
             if (result == null)
             {
@@ -73,7 +73,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> UpdateAsync(User user, bool forceUpdate = false, CancellationToken cancellationToken = default)
         {
-            var commandMessage = UserMessagesFactory.Instance.CreateUpdateMessage(user, forceUpdate);
+            var commandMessage = UserMessagesFactory.Instance.BuildUpdateMessage(user, forceUpdate);
             var result = await this.HassClientWebSocket.SendCommandWithResultAsync<UserResponse>(commandMessage, cancellationToken);
             if (result == null)
             {
@@ -97,7 +97,7 @@ namespace HassClient.WS
         /// </returns>
         public async Task<bool> DeleteAsync(User user, CancellationToken cancellationToken = default)
         {
-            var commandMessage = UserMessagesFactory.Instance.CreateDeleteMessage(user);
+            var commandMessage = UserMessagesFactory.Instance.BuildDeleteMessage(user);
             var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
             if (success)
             {

--- a/src/HassClient.WS/Resources/UsersApi.cs
+++ b/src/HassClient.WS/Resources/UsersApi.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HassClient.Models;
+using HassClient.Serialization;
+using HassClient.WS.Messages;
+
+namespace HassClient.WS
+{
+    /// <summary>
+    /// Represents an API for managing users in Home Assistant.
+    /// </summary>
+    public class UsersApi : ResourceApi
+    {
+        internal UsersApi(HassClientWebSocket webSocket)
+            : base(webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Gets a collection with every registered <see cref="User"/> in the Home Assistant instance.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a collection with
+        /// every registered <see cref="User"/> in the Home Assistant instance.
+        /// </returns>
+        public Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var commandMessage = UserMessagesFactory.Instance.CreateListMessage();
+            return this.HassClientWebSocket.SendCommandWithResultAsync<IEnumerable<User>>(commandMessage, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="User"/>.
+        /// </summary>
+        /// <param name="user">The new <see cref="User"/>.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// create operation was successfully done.
+        /// </returns>
+        public async Task<bool> CreateAsync(User user, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = UserMessagesFactory.Instance.CreateCreateMessage(user);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync<UserResponse>(commandMessage, cancellationToken);
+            if (result == null)
+            {
+                return false;
+            }
+
+            HassSerializer.PopulateObject(result.UserRaw, user);
+            return true;
+        }
+
+        /// <summary>
+        /// Updates an existing <see cref="User"/>.
+        /// </summary>
+        /// <param name="user">The <see cref="User"/> with the new values.</param>
+        /// <param name="forceUpdate">
+        /// Indicates if the update operation should force the update of every modifiable property.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// update operation was successfully done.
+        /// </returns>
+        public async Task<bool> UpdateAsync(User user, bool forceUpdate = false, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = UserMessagesFactory.Instance.CreateUpdateMessage(user, forceUpdate);
+            var result = await this.HassClientWebSocket.SendCommandWithResultAsync<UserResponse>(commandMessage, cancellationToken);
+            if (result == null)
+            {
+                return false;
+            }
+
+            HassSerializer.PopulateObject(result.UserRaw, user);
+            return true;
+        }
+
+        /// <summary>
+        /// Deletes an existing <see cref="User"/>.
+        /// </summary>
+        /// <param name="user">The <see cref="User"/> to delete.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that this operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The result of the task is a boolean indicating if the
+        /// delete operation was successfully done.
+        /// </returns>
+        public async Task<bool> DeleteAsync(User user, CancellationToken cancellationToken = default)
+        {
+            var commandMessage = UserMessagesFactory.Instance.CreateDeleteMessage(user);
+            var success = await this.HassClientWebSocket.SendCommandWithSuccessAsync(commandMessage, cancellationToken);
+            if (success)
+            {
+                user.Untrack();
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/HassClient.sln
+++ b/src/HassClient.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HassClient.WS", "HassClient
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HassClient.WS.Tests", "HassClient.WS.Tests\HassClient.WS.Tests.csproj", "{4D15C578-FA32-485F-A9A4-05F20D4BEF86}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HassClient.Docs.Tests", "HassClient.Docs.Tests\HassClient.Docs.Tests.csproj", "{23456789-ABCD-EF01-2345-6789ABCDEF01}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{4D15C578-FA32-485F-A9A4-05F20D4BEF86}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D15C578-FA32-485F-A9A4-05F20D4BEF86}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4D15C578-FA32-485F-A9A4-05F20D4BEF86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23456789-ABCD-EF01-2345-6789ABCDEF01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23456789-ABCD-EF01-2345-6789ABCDEF01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23456789-ABCD-EF01-2345-6789ABCDEF01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23456789-ABCD-EF01-2345-6789ABCDEF01}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Overview

This PR refactors the existing monolithic `HassWSApi` class by extracting resource-specific methods into dedicated API classes. This improves code organization, maintainability, and makes the codebase more modular while maintaining the same functionality.

### ⚠️ Breaking changes
The methods previously available directly on `HassWSApi` have been moved to their respective API classes. All calls need to be updated to use the new structure:
```csharp
// Old way (NO LONGER WORKS)
await hassWSApi.ListAreasAsync();
await hassWSApi.CreateLabelAsync(label);
await hassWSApi.UpdateDeviceAsync(device);

// New way
await hassWSApi.Areas.ListAsync();
await hassWSApi.Labels.CreateAsync(label);
await hassWSApi.Devices.UpdateAsync(device);
```

### New API Classes
Moved existing functionality into these dedicated classes:
- AreasApi - Area management methods
- CategoriesApi - Category registry operations
- DevicesApi - Device registry operations
- EntitiesEntriesApi - Entity registry management
- FloorsApi - Floor registry operations
- LabelsApi - Label management
- ServicesApi - Service operations
- StorageEntitiesApi - Storage entity operations
- UsersApi - User management


## Implementation Details
- All API classes inherit from `ResourceApi` base class
- Each API class takes `HassClientWebSocket` in constructor
- Original methods removed from `HassWSApi` class
- No changes to underlying `WebSocket` communication

## Testing
- Reorganized tests to match new API structure
- Added new tests for base ResourceApi class
- Updated all tests to use new API structure
- Added tests to ensure Readme code blocks are up-to-date

## Documentation
- Updated XML documentation to reflect new class structure
- Updated examples to show new API usage

## Version Update
Due to breaking changes, this requires a major version bump:
- Version updated from 1.0.15 to 2.0.0

### Migration Guide
- Update all direct method calls to use appropriate API property
- Review and update any extension methods or utilities that wrap `HassWSApi`
- Update tests to use new API structure