### PR TITLE
Expand test coverage and fix subscription-related issues

### DIFF
--- a/src/HassClient.Core/HassClient.Core.csproj
+++ b/src/HassClient.Core/HassClient.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Authors>VFerrer</Authors>
     <Description>A shared package used by HassClient. Do not install this package manually, it will be added as a prerequisite by other packages that require it.</Description>
     <RepositoryUrl>https://github.com/vicfergar/HassClient</RepositoryUrl>

--- a/src/HassClient.WS.Tests/BaseHassWSApiTest.cs
+++ b/src/HassClient.WS.Tests/BaseHassWSApiTest.cs
@@ -12,14 +12,14 @@ namespace HassClient.WS.Tests
         public const string TestsInstanceBaseUrlVar = "TestsInstanceBaseUrl";
         public const string TestsAccessTokenVar = "TestsAccessToken";
 
-        protected readonly CancellationTokenSource cts;
+        private readonly CancellationTokenSource cts;
         private readonly ConnectionParameters connectionParameters;
+        protected readonly HassWSApi hassWSApi;
 
-        protected HassWSApi hassWSApi;
+        protected CancellationToken CancellationToken => this.cts.Token;
 
         public BaseHassWSApiTest()
         {
-            this.cts = new CancellationTokenSource();
             var instanceBaseUrl = Environment.GetEnvironmentVariable(TestsInstanceBaseUrlVar);
             var accessToken = Environment.GetEnvironmentVariable(TestsAccessTokenVar);
 
@@ -33,13 +33,14 @@ namespace HassClient.WS.Tests
                 Assert.Ignore($"Hass access token for tests not provided. It should be set in the environment variable '{TestsAccessTokenVar}'");
             }
 
+            this.cts = new CancellationTokenSource();
             this.connectionParameters = ConnectionParameters.CreateFromInstanceBaseUrl(instanceBaseUrl, accessToken);
+            this.hassWSApi = new HassWSApi();
         }
 
         [OneTimeSetUp]
         protected virtual async Task OneTimeSetUp()
         {
-            this.hassWSApi = new HassWSApi();
             await this.hassWSApi.ConnectAsync(this.connectionParameters, cancellationToken: this.cts.Token);
 
             HassSerializer.DefaultSettings.MissingMemberHandling = Newtonsoft.Json.MissingMemberHandling.Error;

--- a/src/HassClient.WS.Tests/ConnectionEventsTests.cs
+++ b/src/HassClient.WS.Tests/ConnectionEventsTests.cs
@@ -1,0 +1,42 @@
+﻿using HassClient.Models;
+using HassClient.WS.Tests.Mocks;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HassClient.WS.Tests
+{
+    public class ConnectionEventsTests : BaseHassWSApiTest
+    {
+        private MockEventListener connectionChangedListener;
+
+        public ConnectionEventsTests()
+        {
+            this.connectionChangedListener = new MockEventListener();
+            this.hassWSApi.ConnectionStateChanged += this.connectionChangedListener.Handle;
+        }
+        
+        [Test, Order(1)]
+        public void ConnectionStatusChangedRaisedWhenConnecting()
+        {
+            Assert.AreEqual(ConnectionStates.Connected, this.hassWSApi.ConnectionState);
+
+            Assert.AreEqual(3, this.connectionChangedListener.HitCount);
+            Assert.AreEqual(new[] { ConnectionStates.Connecting, ConnectionStates.Authenticating, ConnectionStates.Connected }, this.connectionChangedListener.ReceivedEventArgs);
+            Assert.IsTrue(this.connectionChangedListener.ReceivedEvents.All(e => this.hassWSApi.WebSocket == e.Sender));
+        }
+
+        [Test, Order(2)]
+        public async Task ConnectionStatusChangedRaisedWhenClosing()
+        {
+            Assert.AreEqual(ConnectionStates.Connected, this.hassWSApi.ConnectionState);
+            this.connectionChangedListener.Reset();
+            await this.hassWSApi.CloseAsync();
+            Assert.AreEqual(ConnectionStates.Disconnected, this.hassWSApi.ConnectionState);
+
+            Assert.AreEqual(1, this.connectionChangedListener.HitCount);
+            Assert.AreEqual(ConnectionStates.Disconnected, this.connectionChangedListener.ReceivedEventArgs.FirstOrDefault());
+            Assert.AreEqual(this.hassWSApi.WebSocket, connectionChangedListener.ReceivedEvents.FirstOrDefault().Sender);
+        }
+    }
+}

--- a/src/HassClient.WS.Tests/Mocks/HassServer/CommandProcessors/EventSubscriptionsProcessor.cs
+++ b/src/HassClient.WS.Tests/Mocks/HassServer/CommandProcessors/EventSubscriptionsProcessor.cs
@@ -32,7 +32,7 @@ namespace HassClient.WS.Tests.Mocks.HassServer
             {
                 foreach (var item in this.subscribersByEventType.Values)
                 {
-                    if (item.Remove(unsubscribeMessage.SubscriptionId))
+                    if (item.Remove(unsubscribeMessage.Subscription))
                     {
                         //success = true;
                         break;

--- a/src/HassClient.WS.Tests/StateChangedEventListenerTests.cs
+++ b/src/HassClient.WS.Tests/StateChangedEventListenerTests.cs
@@ -1,0 +1,303 @@
+﻿using HassClient.Helpers;
+using HassClient.Models;
+using HassClient.WS.Tests.Mocks;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using static HassClient.WS.Tests.Mocks.MockEventListener;
+
+namespace HassClient.WS.Tests
+{
+    public class StateChangedEventListenerTests : BaseHassWSApiTest
+    {
+        private const string testLightEntityId1 = "light.ceiling_lights";
+
+        private const string testLightEntityId2 = "light.office_rgbw_lights";
+
+        private const string testSwitchEntityId1 = "switch.decorative_lights";
+
+        private const string testSwitchEntityId2 = "switch.ac";
+
+        private async Task<EventData<StateChangedEvent>> ForceStateChangedAndGetEventData(string entityId, MockEventListener listener)
+        {
+            var domain = entityId.GetDomain();
+            var update = await this.hassWSApi.Services.CallForEntitiesAsync(domain, "toggle", entityId);
+            Assert.NotNull(update, "SetUp failed. Service call failed");
+
+            var eventData = await listener.WaitFirstEventWithTimeoutAsync<StateChangedEvent>(millisecondsTimeout: 500);
+            return eventData;
+        }
+
+        [Test]
+        public async Task SubscribeDomainStatusChanged_WhenEntityInDomainChanges_NotifiesCorrectly()
+        {
+            // Arrange
+            var listener = new MockEventListener();
+            var testDomain = testLightEntityId1.GetDomain();
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener);
+
+            Assert.NotZero(listener.HitCount);
+            Assert.NotNull(eventData);
+            Assert.AreEqual(eventData.Sender, this.hassWSApi.StateChangedEventListener);
+            Assert.AreEqual(eventData.Args.EntityId.GetDomain(), testDomain);
+            Assert.NotNull(eventData.Args.NewState.State);
+        }
+
+        [Test]
+        public async Task SubscribeDomainStatusChanged_MultipleSubscriptions_NotifiesCorrectly()
+        {
+            // Arrange
+            var listener1 = new MockEventListener();
+            var listener2 = new MockEventListener();
+            var testDomain1 = testLightEntityId1.GetDomain();
+            var testDomain2 = testSwitchEntityId1.GetDomain();
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain1, listener1.Handle);
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain2, listener2.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var eventData1 = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener1);
+            var eventData2 = await this.ForceStateChangedAndGetEventData(testSwitchEntityId1, listener2);
+
+            Assert.NotZero(listener1.HitCount);
+            Assert.NotZero(listener2.HitCount);
+            Assert.NotNull(eventData1);
+            Assert.NotNull(eventData2);
+            Assert.AreEqual(eventData1.Sender, this.hassWSApi.StateChangedEventListener);
+            Assert.AreEqual(eventData2.Sender, this.hassWSApi.StateChangedEventListener);
+            Assert.AreEqual(eventData1.Args.EntityId.GetDomain(), testDomain1);
+            Assert.AreEqual(eventData2.Args.EntityId.GetDomain(), testDomain2);
+            Assert.NotNull(eventData1.Args.NewState.State);
+            Assert.NotNull(eventData2.Args.NewState.State);
+        }
+
+        [Test]
+        public async Task SubscribeDomainStatusChanged_WhenEntityNotInDomainChanges_DoesNotNotify()
+        {
+            // Arrange
+            var listener = new MockEventListener();
+            var testDomain = testLightEntityId1.GetDomain();
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var otherDomainEntityId = testSwitchEntityId1;
+            var eventData = await this.ForceStateChangedAndGetEventData(otherDomainEntityId, listener);
+
+            Assert.Zero(listener.HitCount);
+            Assert.Null(eventData);
+        }
+        
+        [Test]
+        public async Task SubscribeMultipleListenersSameDomain_WhenDomainEntityChanges_NotifiesAllListeners()
+        {
+            // Arrange
+            var listener1 = new MockEventListener();
+            var listener2 = new MockEventListener();
+            var listener3 = new MockEventListener();
+            var testDomain = testLightEntityId1.GetDomain();
+            
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener1.Handle);
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener2.Handle);
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener3.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener1);
+
+            // Assert
+            Assert.NotNull(eventData);
+            Assert.NotZero(listener1.HitCount);
+            Assert.NotZero(listener2.HitCount);
+            Assert.NotZero(listener3.HitCount);
+        }
+
+        [Test]
+        public async Task UnsubscribeDomainStatusChanged_WhenEntityInDomainChanges_DoesNotNotify()
+        {
+            // Arrange
+            var listener = new MockEventListener();
+            var testDomain = testLightEntityId1.GetDomain();
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act - First change should be received
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener);
+            Assert.NotNull(eventData, "First event should be received");
+
+            // Unsubscribe and try again
+            this.hassWSApi.StateChangedEventListener.UnsubscribeDomainStatusChanged(testDomain, listener.Handle);
+            
+            listener.Reset();
+            var secondEventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener);
+
+            // Assert
+            Assert.Zero(listener.HitCount, "Should not receive events after unsubscribe");
+            Assert.Null(secondEventData);
+        }
+
+        [Test]
+        public async Task UnsubscribeOneOfMultipleDomainListeners_WhenDomainEntityChanges_OnlyNotifiesRemainingListeners()
+        {
+            // Arrange
+            var listener1 = new MockEventListener();
+            var listener2 = new MockEventListener();
+            var testDomain = testLightEntityId1.GetDomain();
+            
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener1.Handle);
+            this.hassWSApi.StateChangedEventListener.SubscribeDomainStatusChanged(testDomain, listener2.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            this.hassWSApi.StateChangedEventListener.UnsubscribeDomainStatusChanged(testDomain, listener1.Handle);
+            
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener2);
+
+            // Assert
+            Assert.NotNull(eventData);
+            Assert.Zero(listener1.HitCount);
+            Assert.NotZero(listener2.HitCount);
+        }
+
+        [Test]
+        public async Task SubscribeEntityStatusChanged_WhenEntityChanges_NotifiesCorrectly()
+        {
+            // Arrange
+            var listener = new MockEventListener();
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener);
+
+            Assert.NotZero(listener.HitCount);
+            Assert.NotNull(eventData);
+            Assert.AreEqual(eventData.Sender, this.hassWSApi.StateChangedEventListener);
+            Assert.IsTrue(eventData.Args.EntityId == testLightEntityId1);
+            Assert.NotNull(eventData.Args.NewState.State);
+        }
+
+        [Test]
+        public async Task SubscribeEntityStatusChanged_WhenOtherEntityChanges_DoesNotNotify()
+        {
+            // Arrange
+            var listener = new MockEventListener();
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var otherEntityId = testSwitchEntityId1;
+            var eventData = await this.ForceStateChangedAndGetEventData(otherEntityId, listener);
+
+            Assert.Zero(listener.HitCount);
+            Assert.Null(eventData);
+        }
+
+        [Test]
+        public async Task SubscribeEntityStatusChanged_MultipleSubscriptions_NotifiesCorrectly()
+        {
+            // Arrange
+            var listener1 = new MockEventListener();
+            var listener2 = new MockEventListener();
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener1.Handle);
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testSwitchEntityId2, listener2.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var eventData1 = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener1);
+            var eventData2 = await this.ForceStateChangedAndGetEventData(testSwitchEntityId2, listener2);
+
+            Assert.NotZero(listener1.HitCount);
+            Assert.NotZero(listener2.HitCount);
+            Assert.NotNull(eventData1);
+            Assert.NotNull(eventData2);
+            Assert.AreEqual(eventData1.Sender, this.hassWSApi.StateChangedEventListener);
+            Assert.AreEqual(eventData2.Sender, this.hassWSApi.StateChangedEventListener);
+            Assert.IsTrue(eventData1.Args.EntityId == testLightEntityId1);
+            Assert.IsTrue(eventData2.Args.EntityId == testSwitchEntityId2);
+            Assert.NotNull(eventData1.Args.NewState.State);
+            Assert.NotNull(eventData2.Args.NewState.State);
+        }
+
+        [Test]
+        public async Task SubscribeMultipleListenersToSameEntity_WhenEntityChanges_NotifiesAllListeners()
+        {
+            // Arrange
+            var listener1 = new MockEventListener();
+            var listener2 = new MockEventListener();
+            var listener3 = new MockEventListener();
+            
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener1.Handle);
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener2.Handle);
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener3.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener1);
+
+            // Assert
+            Assert.NotNull(eventData);
+            Assert.NotZero(listener1.HitCount);
+            Assert.NotZero(listener2.HitCount);
+            Assert.NotZero(listener3.HitCount);
+        }
+
+        [Test]
+        public async Task UnsubscribeEntityStatusChanged_WhenEntityChanges_DoesNotNotify()
+        {
+            // Arrange
+            var listener = new MockEventListener();
+            this.hassWSApi.StateChangedEventListener.SubscribeEntityStatusChanged(testLightEntityId1, listener.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act - First change should be received
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener);
+            Assert.NotNull(eventData, "First event should be received");
+
+            // Unsubscribe and try again
+            this.hassWSApi.StateChangedEventListener.UnsubscribeEntityStatusChanged(testLightEntityId1, listener.Handle);
+            
+            listener.Reset();
+            var secondEventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener);
+
+            // Assert
+            Assert.Zero(listener.HitCount, "Should not receive events after unsubscribe");
+            Assert.Null(secondEventData);
+        }
+
+        [Test]
+        public async Task UnsubscribeOneOfMultipleListeners_WhenEntityChanges_OnlyNotifiesRemainingListeners()
+        {
+            // Arrange
+            var listener1 = new MockEventListener();
+            var listener2 = new MockEventListener();
+            
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener1.Handle);
+            this.hassWSApi.StateChangedEventListener
+                .SubscribeEntityStatusChanged(testLightEntityId1, listener2.Handle);
+            await this.hassWSApi.StateChangedEventListener.WaitForSubscriptionCompletedAsync();
+
+            // Act
+            this.hassWSApi.StateChangedEventListener
+                .UnsubscribeEntityStatusChanged(testLightEntityId1, listener1.Handle);
+            
+            var eventData = await this.ForceStateChangedAndGetEventData(testLightEntityId1, listener2);
+
+            // Assert
+            Assert.NotNull(eventData);
+            Assert.Zero(listener1.HitCount);
+            Assert.NotZero(listener2.HitCount);
+        }
+    }
+}

--- a/src/HassClient.WS.Tests/SubscriptionApiTests.cs
+++ b/src/HassClient.WS.Tests/SubscriptionApiTests.cs
@@ -17,14 +17,14 @@ namespace HassClient.WS.Tests
         {
             var domain = testEntityId.GetDomain();
             var update = await this.hassWSApi.Services.CallForEntitiesAsync(domain, "toggle", testEntityId);
-            Assert.NotNull(update, "SetUp failed");
+            Assert.NotNull(update, "SetUp failed. Service call failed");
 
             var eventData = await listener.WaitFirstEventWithTimeoutAsync<EventResultInfo>(
-                                            (x) => HassSerializer.TryGetEnumFromSnakeCase<KnownEventTypes>(x.EventType, out var knownEventType) &&
-                                                   knownEventType == KnownEventTypes.StateChanged,
-                                            500);
+                    (x) => HassSerializer.TryGetEnumFromSnakeCase<KnownEventTypes>(x.EventType, out var knownEventType) &&
+                            knownEventType == KnownEventTypes.StateChanged,
+                    millisecondsTimeout: 500);
 
-            Assert.NotNull(eventData, "SetUp failed");
+            Assert.NotNull(eventData, "SetUp failed. Event not received");
 
             var args = eventData.Args.DeserializeData<StateChangedEvent>();
             return new EventData<StateChangedEvent>(eventData.Sender, args);

--- a/src/HassClient.WS/HASSClientWebSocket.cs
+++ b/src/HassClient.WS/HASSClientWebSocket.cs
@@ -780,7 +780,7 @@ namespace HassClient.WS
 
             if (socketEventSubscription.SubscriptionCount == 0)
             {
-                var subscribeMessage = new UnsubscribeEventsMessage() { SubscriptionId = socketEventSubscription.SubscriptionId };
+                var subscribeMessage = new UnsubscribeEventsMessage() { Subscription = socketEventSubscription.SubscriptionId };
                 if (!await this.SendCommandWithSuccessAsync(subscribeMessage, cancellationToken))
                 {
                     return false;

--- a/src/HassClient.WS/HASSClientWebSocket.cs
+++ b/src/HassClient.WS/HASSClientWebSocket.cs
@@ -776,7 +776,10 @@ namespace HassClient.WS
                 return false;
             }
 
-            socketEventSubscription.RemoveSubscription(value);
+            if (!socketEventSubscription.RemoveSubscription(value))
+            {
+                return false;
+            }
 
             if (socketEventSubscription.SubscriptionCount == 0)
             {

--- a/src/HassClient.WS/HassClient.WS.csproj
+++ b/src/HassClient.WS/HassClient.WS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Authors>VFerrer</Authors>
     <Description>A Home Assistant WebSocket client to communicate with Home Assistant instances.</Description>
     <RepositoryUrl>https://github.com/vicfergar/HassClient</RepositoryUrl>

--- a/src/HassClient.WS/Messages/Commands/Subscriptions/UnsubscribeEventsMessage.cs
+++ b/src/HassClient.WS/Messages/Commands/Subscriptions/UnsubscribeEventsMessage.cs
@@ -5,7 +5,7 @@ namespace HassClient.WS.Messages
     internal class UnsubscribeEventsMessage : BaseOutgoingMessage
     {
         [JsonProperty(Required = Required.Always)]
-        public uint SubscriptionId { get; set; }
+        public uint Subscription { get; set; }
 
         public UnsubscribeEventsMessage()
             : base("unsubscribe_events")

--- a/src/HassClient.WS/SocketEventSubscription.cs
+++ b/src/HassClient.WS/SocketEventSubscription.cs
@@ -25,10 +25,23 @@ namespace HassClient.WS
             this.SubscriptionCount++;
         }
 
-        public void RemoveSubscription(EventHandler<EventResultInfo> eventHandler)
+        public bool RemoveSubscription(EventHandler<EventResultInfo> eventHandler)
         {
+            if (this.internalEventHandler == null)
+            {
+                return false;
+            }
+
+            var beforeCount = this.internalEventHandler.GetInvocationList().Length;
             this.internalEventHandler -= eventHandler;
-            this.SubscriptionCount--;
+            var afterCount = this.internalEventHandler?.GetInvocationList().Length ?? 0;
+            if (beforeCount > afterCount)
+            {
+                this.SubscriptionCount--;
+                return true;
+            }
+
+            return false;
         }
 
         public void Invoke(EventResultInfo eventResultInfo)


### PR DESCRIPTION
This PR enhances the test coverage for the subscriptions API and StateChangedEventListener while fixing several critical issues related to event handling and unsubscription logic.

## Key changes
### Bug Fixes
- Fixed incorrect message format in `unsubscribe_events` type
- Corrected `RemoveEventHandlerSubscriptionAsync` method to properly handle unregistered handlers
- Resolved an issue where unsubscribe methods weren't working with multiple subscriptions

### Test Coverage Improvements
- Added comprehensive integration tests for StateChangedEventListener
- Expanded test coverage for the Subscriptions API
- Added Connection event integration tests

NOTE: Version bumped from 2.0.1 to 2.0.2 to reflect the bug fixes

Related to #8 